### PR TITLE
Add parameter sample data.

### DIFF
--- a/dev/data/parameter.json
+++ b/dev/data/parameter.json
@@ -1,0 +1,25 @@
+[{
+    "questionOne": "foo",
+    "questionTwo": "bar"
+}, {
+    "questionOne": "boo",
+    "questionTwo": "baz"
+}, {
+    "questionOne": "foo",
+    "questionTwo": "baz"
+}, {
+    "questionOne": "woo",
+    "questionTwo": "bar"
+}, {
+    "questionOne": "foo",
+    "questionTwo": "bat"
+}, {
+    "questionOne": "boo",
+    "questionTwo": "bar"
+}, {
+    "questionOne": "foo",
+    "questionTwo": "bar"
+}, {
+    "questionOne": "foo",
+    "questionTwo": "bat"
+}]


### PR DESCRIPTION
Added for:  https://openscience.atlassian.net/browse/LEI-31
# Purpose

We needed to evaluate whether or not elasticsearch URI query API would support our search needs, in particular for the use case of sampling normalization for parameter selection. 

The long-term solution is to add an read-only aggregation table 'parameter' that collects all experimental parameters (along with session id?). This collection can then be queried to see counts for each enum from the sample set. The caveat with this approach is that we'd have to make N-1 requests to determine this (when N = the size of the enum set). Not ideal... 
