### PR TITLE
Add support for namespaces (and permissions)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,24 +11,24 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.js]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.hbs]
 insert_final_newline = false
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.css]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.html]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.{diff,md}]
 trim_trailing_whitespace = false

--- a/app/adapters/admin.js
+++ b/app/adapters/admin.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+import JamCollectionAdapter from '../mixins/jam-collection-adapter';
+
+export default ApplicationAdapter.extend(JamCollectionAdapter, {
+});

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -12,16 +12,7 @@ export default DS.JSONAPIAdapter.extend(DataAdapterMixin, UrlTemplates, {
   host: ENV.JAMDB.url,
   namespace: 'v1/id',
 
-  findRecordUrlTemplate: '{+host}/{+namespace}/documents{/jamNamespace}.{+collectionId}.{id}',
-  findAllUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
-  queryUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/_search',
-
-  createRecordUrlTemplate: '{+host}/v2/namespaces{/jamNamespace}/collections',
-  // TODO: Find delete URL for JAM
-  // TODO: Create a page with admin-creation. (just admin collection record, not permissions, to start)
-
   urlSegments: {
-    collectionId: (type, id, snapshot, query) => Ember.Inflector.inflector.pluralize(type),
     jamNamespace: () => ENV.JAMDB.namespace
   }
 });

--- a/app/adapters/collection.js
+++ b/app/adapters/collection.js
@@ -1,0 +1,10 @@
+/*
+Manage data about a given collection
+ */
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+    // TODO: What is the endpoint to find a list of all collections?
+    findRecordUrlTemplate: '{+host}/{+namespace}/collections/{+jamNamespace}.{+id}',
+    createRecordUrlTemplate: '{+host}/v2/namespaces{/namespaceId}/collections',
+});

--- a/app/adapters/config.js
+++ b/app/adapters/config.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+import JamCollectionAdapter from '../mixins/jam-collection-adapter';
+
+export default ApplicationAdapter.extend(JamCollectionAdapter, {
+});

--- a/app/adapters/experiment.js
+++ b/app/adapters/experiment.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+import JamCollectionAdapter from '../mixins/jam-collection-adapter';
+
+export default ApplicationAdapter.extend(JamCollectionAdapter, {
+});

--- a/app/adapters/history.js
+++ b/app/adapters/history.js
@@ -1,10 +1,7 @@
 import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
-    queryUrlTemplate: '{+host}/{+namespace}/documents{/documentId}/history',  // TODO: should be id of form namespace.collection.id
     findRecordUrlTemplate: '{+host}/{+namespace}/documents{/documentId}/history',  // TODO: should be id of form namespace.collection.id,
-    findAllUrlTemplate: null,
-    // TODO Deal with irrelevant (collection-specific) URLs inherited from ApplicationAdapter
 
     urlSegments: {
         documentId(type, id, snapshot, query) {

--- a/app/adapters/session.js
+++ b/app/adapters/session.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+import JamCollectionAdapter from '../mixins/jam-collection-adapter';
+
+export default ApplicationAdapter.extend(JamCollectionAdapter, {
+});

--- a/app/components/permissions-editor.js
+++ b/app/components/permissions-editor.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+let PermissionsEditor = Ember.Component.extend({
+  tagName: 'table',
+  classNames: ['table'],
+  permissionLevels: [
+    'CREATE',
+    'READ',
+    'UPDATE',
+    'DELETE',
+    'ADMIN',
+  ],
+
+  newPermissionLevel: 'CREATE',
+  newPermissionSelector: '',
+
+  actions: {
+    addPermission() {
+      this.permissions[this.get('newPermissionSelector')] = this.get('newPermissionLevel');
+      this.set('newPermissionSelector', '');
+      this.rerender();
+      this.get('onchange')(this.get('permissions'));
+    }
+  }
+});
+
+PermissionsEditor.reopenClass({
+    positionalParams: ['permissions'],
+});
+
+
+export default PermissionsEditor;

--- a/app/components/permissions-editor.js
+++ b/app/components/permissions-editor.js
@@ -1,27 +1,35 @@
 import Ember from 'ember';
 
+// FIXME: Known bug in original- if the server save request fails, the value will appear to have been added until page reloaded.
+//  (need to catch and handle errors)
 let PermissionsEditor = Ember.Component.extend({
-  tagName: 'table',
-  classNames: ['table'],
-  permissionLevels: [
-    'CREATE',
-    'READ',
-    'UPDATE',
-    'DELETE',
-    'ADMIN',
-  ],
+    tagName: 'table',
+    classNames: ['table'],
+    permissionLevels: [
+        'CREATE',
+        'READ',
+        'UPDATE',
+        'DELETE',
+        'ADMIN',
+    ],
 
-  newPermissionLevel: 'CREATE',
-  newPermissionSelector: '',
+    newPermissionLevel: 'CREATE',
+    newPermissionSelector: '',
 
-  actions: {
-    addPermission() {
-      this.permissions[this.get('newPermissionSelector')] = this.get('newPermissionLevel');
-      this.set('newPermissionSelector', '');
-      this.rerender();
-      this.get('onchange')(this.get('permissions'));
+    actions: {
+        addPermission() {
+            this.permissions[this.get('newPermissionSelector')] = this.get('newPermissionLevel');
+            this.set('newPermissionSelector', '');
+            this.rerender();
+            this.get('onchange')(this.get('permissions'));
+        },
+
+        removePermission(selector) {
+            delete this.permissions[selector];
+            this.rerender();
+            this.get('onchange')(this.get('permissions'));
+        },
     }
-  }
 });
 
 PermissionsEditor.reopenClass({

--- a/app/controllers/project-settings.js
+++ b/app/controllers/project-settings.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+    actions: {
+        permissionsUpdated(permissions) {
+            this.set('model.permissions', permissions);
+            this.get('model').save();
+        }
+    }
+});

--- a/app/mixins/jam-collection-adapter.js
+++ b/app/mixins/jam-collection-adapter.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+    findRecordUrlTemplate: '{+host}/{+namespace}/documents{/jamNamespace}.{+collectionId}.{id}',
+    findAllUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/documents',
+    queryUrlTemplate: '{+host}/{+namespace}/collections{/jamNamespace}.{+collectionId}/_search',
+
+    createRecordUrlTemplate: '{+host}/v2/namespaces{/jamNamespace}/collections',
+    // TODO: Find delete URL for JAM
+    // TODO: Create a page with admin-creation. (just admin collection record, not permissions, to start)
+
+    urlSegments: {
+        collectionId: (type, id, snapshot, query) => Ember.Inflector.inflector.pluralize(type),
+    }
+});

--- a/app/mixins/jam-collection-serializer.js
+++ b/app/mixins/jam-collection-serializer.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+    payloadKeyFromModelName: function(modelName) {
+        // JamDB expects all collections to specify JSONAPI type 'documents'
+        return 'documents';
+    },
+
+    extractRelationships: function(modelClass, resourceHash) {
+        var relationships = this._super(...arguments);
+        // Manually rebuild the history relationship. This can be removed upon resolution of
+        // issue with the auto-generated history link: ticket https://github.com/CenterForOpenScience/jamdb/issues/3
+        relationships.history.links.related = 'http://localhost:1212/v1/id/documents/' + resourceHash.id + '/history';
+        relationships.history.links.self = relationships.history.links.related;
+        return relationships;
+    },
+});

--- a/app/mixins/jam-serializer.js
+++ b/app/mixins/jam-serializer.js
@@ -17,11 +17,6 @@ export default Ember.Mixin.create({
     return this.modelName || this._super(key);
   },
 
-  payloadKeyFromModelName: function(modelName) {
-    // JamDB expects all collections to specify JSONAPI type 'documents'
-    return 'documents';
-  },
-
   extractRelationships: function(modelClass, resourceHash) {
     var relationships = this._super(...arguments);
     // Some relationships are stored as ID list under attributes; convert to JSONAPI format
@@ -34,13 +29,6 @@ export default Ember.Mixin.create({
             type: Ember.Inflector.inflector.singularize(relName), // Must match this.modelName
           }))
       };
-    }
-
-    // Manually rebuild the history relationship. This can be removed upon resolution of
-    // issue with the auto-generated history link: ticket https://github.com/CenterForOpenScience/jamdb/issues/3
-    if (this.modelName !== 'history' && this.modelName !== 'namespace') {
-      relationships.history.links.related = 'http://localhost:1212/v1/id/documents/' + resourceHash.id + '/history';
-      relationships.history.links.self = relationships.history.links.related;
     }
     return relationships;
   }

--- a/app/mixins/jam-serializer.js
+++ b/app/mixins/jam-serializer.js
@@ -38,7 +38,7 @@ export default Ember.Mixin.create({
 
     // Manually rebuild the history relationship. This can be removed upon resolution of
     // issue with the auto-generated history link: ticket https://github.com/CenterForOpenScience/jamdb/issues/3
-    if (this.modelName !== 'history') {
+    if (this.modelName !== 'history' && this.modelName !== 'namespace') {
       relationships.history.links.related = 'http://localhost:1212/v1/id/documents/' + resourceHash.id + '/history';
       relationships.history.links.self = relationships.history.links.related;
     }

--- a/app/mixins/jam-serializer.js
+++ b/app/mixins/jam-serializer.js
@@ -4,32 +4,41 @@ import Ember from 'ember';
 Convert JamDB responses to and from models
  */
 export default Ember.Mixin.create({
-  modelName: null,
-  relationAttrs: [],  // List of field names (in JSONAPI attributes) that denote relationships
+    modelName: null,
+    relationAttrs: [],  // List of field names (in JSONAPI attributes) that denote relationships
 
-  keyForAttribute: function(attr, method) {
+    // Suppress fields that should not be sent to the server
+    attrs: {
+        createdOn: {serialize: false},
+        createdBy: {serialize: false},
+        modifiedOn: {serialize: false},
+        modifiedBy: {serialize: false},
+    },
+
+
+    keyForAttribute: function(attr, method) {
     // Override the default ember data behavior, so that Jam can use exactly the same keys as in the model (no dasherizing)
-    return attr;
-  },
+        return attr;
+    },
 
-  modelNameFromPayloadKey: function(key) {
+    modelNameFromPayloadKey: function(key) {
     // Replace the generic JamDB response type of 'documents' with the name of the model to deserialize as
-    return this.modelName || this._super(key);
-  },
+        return this.modelName || this._super(key);
+    },
 
-  extractRelationships: function(modelClass, resourceHash) {
-    var relationships = this._super(...arguments);
-    // Some relationships are stored as ID list under attributes; convert to JSONAPI format
-    // TODO: May need serialization for return to server?
-    for (var relName of this.relationAttrs) {
-      var relData = resourceHash.attributes[relName] || [];
-      relationships[relName] = {
-        data: relData.map(idVal => ({
-            id: idVal,
-            type: Ember.Inflector.inflector.singularize(relName), // Must match this.modelName
-          }))
-      };
+    extractRelationships: function(modelClass, resourceHash) {
+        var relationships = this._super(...arguments);
+        // Some relationships are stored as ID list under attributes; convert to JSONAPI format
+        // TODO: May need serialization for return to server?
+        for (var relName of this.relationAttrs) {
+          var relData = resourceHash.attributes[relName] || [];
+          relationships[relName] = {
+            data: relData.map(idVal => ({
+                id: idVal,
+                type: Ember.Inflector.inflector.singularize(relName), // Must match this.modelName
+              }))
+          };
+        }
+        return relationships;
     }
-    return relationships;
-  }
 });

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -1,3 +1,7 @@
+/*
+Manage data about one or more documents in the accounts collection
+ */
+
 import DS from 'ember-data';
 
 export default DS.Model.extend({

--- a/app/models/admin.js
+++ b/app/models/admin.js
@@ -1,3 +1,7 @@
+/*
+Manage data about one or more documents in the admin collection
+ */
+
 import DS from 'ember-data';
 
 export default DS.Model.extend({

--- a/app/models/collection.js
+++ b/app/models/collection.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+
+
+// Store data about a collection
+export default DS.Model.extend({
+    name: function() {
+      return this.get('id').split('.')[1];
+    }.property(),
+    permissions: DS.attr(),
+    namespace: DS.belongsTo('namespace'),
+});

--- a/app/models/config.js
+++ b/app/models/config.js
@@ -1,3 +1,7 @@
+/*
+Manage data about one or more documents in the config collection
+ */
+
 import DS from 'ember-data';
 
 export default DS.Model.extend({

--- a/app/models/experiment.js
+++ b/app/models/experiment.js
@@ -1,3 +1,7 @@
+/*
+Manage data about one or more documents in the experiments collection
+ */
+
 import DS from 'ember-data';
 
 export default DS.Model.extend({

--- a/app/models/history.js
+++ b/app/models/history.js
@@ -1,3 +1,7 @@
+/*
+Manage the history of a specified document
+ */
+
 import DS from 'ember-data';
 
 Ember.Inflector.inflector.uncountable('history');

--- a/app/models/namespace.js
+++ b/app/models/namespace.js
@@ -1,3 +1,7 @@
+/*
+Manage data about the shared project namespace
+ */
+
 import Ember from 'ember';
 import DS from 'ember-data';
 

--- a/app/models/namespace.js
+++ b/app/models/namespace.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+
+var osfRegex = /^user-osf-([^*]{5,})$/;  // Pattern for externally validated users authenticated via OSF
+
+export default DS.Model.extend({
+    name: DS.attr('string'),
+    permissions: DS.attr(),
+    createdOn: DS.attr('date'),
+
+    // Filter the permissions list to just the OSF-authenticated users
+    osfUsers: Ember.computed('permissions', function() {
+        let permissions = this.get('permissions');
+        var res = {};
+        for (var k in permissions) {
+            if (permissions.hasOwnProperty(k)) {
+                var match = osfRegex.exec(k);
+                if (match) {
+                    // Only store OSF id for display purposes, not whole string
+                    res[match[1]] = permissions[k];
+                }
+            }
+        }
+        return res;
+    }),
+});

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -1,3 +1,7 @@
+/*
+Manage data about one or more documents in the sessions collection
+ */
+
 import DS from 'ember-data';
 
 export default DS.Model.extend({

--- a/app/router.js
+++ b/app/router.js
@@ -25,6 +25,7 @@ Router.map(function() {
     });
     this.route('participants');
     this.route('settings');
+    this.route('project-settings');
 });
 
 export default Router;

--- a/app/routes/project-settings.js
+++ b/app/routes/project-settings.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+import ENV from 'experimenter/config/environment';
+
+export default Ember.Route.extend(AuthenticatedRouteMixin, {
+    model(params) {
+        return this.store.find('namespace', ENV.JAMDB.namespace);
+    }
+});

--- a/app/serializers/account.js
+++ b/app/serializers/account.js
@@ -1,8 +1,9 @@
 import DS from 'ember-data';
 
 import JamSerializer from '../mixins/jam-serializer';
+import JamCollectionSerializer from '../mixins/jam-collection-serializer';
 
-export default DS.JSONAPISerializer.extend(JamSerializer, {
+export default DS.JSONAPISerializer.extend(JamSerializer, JamCollectionSerializer, {
   modelName: 'account',
   relationAttrs: ['sessions'],
 });

--- a/app/serializers/admin.js
+++ b/app/serializers/admin.js
@@ -2,8 +2,9 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 import JamSerializer from '../mixins/jam-serializer';
+import JamCollectionSerializer from '../mixins/jam-collection-serializer';
 
-export default DS.JSONAPISerializer.extend(JamSerializer, {
+export default DS.JSONAPISerializer.extend(JamSerializer, JamCollectionSerializer, {
   modelName: 'admin',
   relationAttrs: ['experiments'],
 });

--- a/app/serializers/collection.js
+++ b/app/serializers/collection.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+import JamSerializer from '../mixins/jam-serializer';
+
+export default DS.JSONAPISerializer.extend(JamSerializer, {
+    modelName: 'collection',
+});

--- a/app/serializers/config.js
+++ b/app/serializers/config.js
@@ -1,8 +1,8 @@
 import DS from 'ember-data';
 
-
 import JamSerializer from '../mixins/jam-serializer';
+import JamCollectionSerializer from '../mixins/jam-collection-serializer';
 
-export default DS.JSONAPISerializer.extend(JamSerializer, {
+export default DS.JSONAPISerializer.extend(JamSerializer, JamCollectionSerializer, {
   modelName: 'config',
 });

--- a/app/serializers/experiment.js
+++ b/app/serializers/experiment.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 
 import JamSerializer from '../mixins/jam-serializer';
+import JamCollectionSerializer from '../mixins/jam-collection-serializer';
 
-export default DS.JSONAPISerializer.extend(JamSerializer, {
-  modelName: 'experiment',
+export default DS.JSONAPISerializer.extend(JamSerializer, JamCollectionSerializer, {  modelName: 'experiment',
 });

--- a/app/serializers/namespace.js
+++ b/app/serializers/namespace.js
@@ -4,4 +4,9 @@ import JamSerializer from '../mixins/jam-serializer';
 
 export default DS.JSONAPISerializer.extend(JamSerializer, {
     modelName: 'namespace',
+
+    attrs: {
+        name: {serialize: false}
+    }
+
 });

--- a/app/serializers/namespace.js
+++ b/app/serializers/namespace.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+import JamSerializer from '../mixins/jam-serializer';
+
+export default DS.JSONAPISerializer.extend(JamSerializer, {
+    modelName: 'namespace',
+});

--- a/app/serializers/session.js
+++ b/app/serializers/session.js
@@ -1,7 +1,8 @@
 import DS from 'ember-data';
 
 import JamSerializer from '../mixins/jam-serializer';
+import JamCollectionSerializer from '../mixins/jam-collection-serializer';
 
-export default DS.JSONAPISerializer.extend(JamSerializer, {
-  modelName: 'session'
+export default DS.JSONAPISerializer.extend(JamSerializer, JamCollectionSerializer, {
+    modelName: 'session'
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -16,13 +16,14 @@
 </header>
 
 <aside class="main-sidebar">
-  <section class="sidebar" style="height: auto;">    
+  <section class="sidebar" style="height: auto;">
     <div class="user-panel" style="display: flex; justify-content: center;"></div>
     <ul class="nav sidebar-menu">
       <li class="header">Menu</li>
       <li> {{#link-to 'experiments'}}Experiments{{/link-to}} </li>
       <li> {{#link-to 'participants'}}Participants{{/link-to}} </li>
       <li> {{#link-to 'settings'}}Profile Settings{{/link-to}} </li>
+      <li> {{#link-to "project-settings"}}Project Settings{{/link-to}} </li>
     </ul>
   </section>
 </aside>

--- a/app/templates/components/permissions-editor.hbs
+++ b/app/templates/components/permissions-editor.hbs
@@ -1,0 +1,33 @@
+<thead>
+  <tr>
+    <th width="5%"></th>
+    <th>User Selector</th>
+    <th>Permission Level</th>
+  </tr>
+</thead>
+<tbody>
+{{#each-in permissions as |user-selector permission|}}
+  <tr>
+    <td></td>
+    <td>{{user-selector}}</td>
+    <td>{{permission}}</td>
+  </tr>
+{{/each-in}}
+  <tr>
+    <td>
+      <button {{action 'addPermission'}} class="btn btn-xs bg-black">
+        <i class="fa fa-plus"></i>
+      </button>
+    </td>
+    <td>
+      {{input value=newPermissionSelector type="text" class="form-control"}}
+    </td>
+    <td>
+      <select onchange={{action (mut newPermissionLevel) value="target.value"}}>
+        {{#each permissionLevels as |permission|}}
+          <option>{{permission}}</option>
+        {{/each}}
+      </select>
+    </td>
+  </tr>
+</tbody>

--- a/app/templates/components/permissions-editor.hbs
+++ b/app/templates/components/permissions-editor.hbs
@@ -1,24 +1,23 @@
 <thead>
   <tr>
-    <th width="5%"></th>
     <th>User Selector</th>
     <th>Permission Level</th>
+    <th width="5%">Add / remove</th>
   </tr>
 </thead>
 <tbody>
 {{#each-in permissions as |user-selector permission|}}
   <tr>
-    <td></td>
     <td>{{user-selector}}</td>
     <td>{{permission}}</td>
+    <td>
+      <button {{action 'removePermission' user-selector}} class="btn btn-xs bg-red">
+        <i class="fa fa-remove"></i>
+      </button>
+    </td>
   </tr>
 {{/each-in}}
   <tr>
-    <td>
-      <button {{action 'addPermission'}} class="btn btn-xs bg-black">
-        <i class="fa fa-plus"></i>
-      </button>
-    </td>
     <td>
       {{input value=newPermissionSelector type="text" class="form-control"}}
     </td>
@@ -28,6 +27,11 @@
           <option>{{permission}}</option>
         {{/each}}
       </select>
+    </td>
+    <td>
+      <button {{action 'addPermission'}} class="btn btn-xs bg-black">
+        <i class="fa fa-plus"></i>
+      </button>
     </td>
   </tr>
 </tbody>

--- a/app/templates/project-settings.hbs
+++ b/app/templates/project-settings.hbs
@@ -6,4 +6,6 @@
     <hr>
 {{/each-in}}
 
+{{permissions-editor model.permissions onchange=(action 'permissionsUpdated')}}
+
 {{outlet}}

--- a/app/templates/project-settings.hbs
+++ b/app/templates/project-settings.hbs
@@ -1,10 +1,9 @@
 <h1>Project Settings</h1>
 <!--TODO: Add permissions widget that shows permission and optionally updates entire list -->
 
-{{#each-in model.osfUsers as |userId permission|}}
-    ID: {{userId}} / Permission level: {{permission}}<br>
-    <hr>
-{{/each-in}}
+
+<h2>Add administrator to project</h2>
+<p>Enter the OSF ID for the desired user, one per line.</p>
 
 {{permissions-editor model.permissions onchange=(action 'permissionsUpdated')}}
 

--- a/app/templates/project-settings.hbs
+++ b/app/templates/project-settings.hbs
@@ -1,0 +1,9 @@
+<h1>Project Settings</h1>
+<!--TODO: Add permissions widget that shows permission and optionally updates entire list -->
+
+{{#each-in model.osfUsers as |userId permission|}}
+    ID: {{userId}} / Permission level: {{permission}}<br>
+    <hr>
+{{/each-in}}
+
+{{outlet}}

--- a/app/templates/project-settings.hbs
+++ b/app/templates/project-settings.hbs
@@ -3,7 +3,7 @@
 
 
 <h2>Add administrator to project</h2>
-<p>Enter the OSF ID for the desired user, one per line.</p>
+<p>Enter the permissions string for the desired user, one per line.</p>
 
 {{permissions-editor model.permissions onchange=(action 'permissionsUpdated')}}
 

--- a/tests/integration/components/permissions-editor-test.js
+++ b/tests/integration/components/permissions-editor-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('permissions-editor', 'Integration | Component | permissions editor', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });"
+
+  this.render(hbs`{{permissions-editor}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:"
+  this.render(hbs`
+    {{#permissions-editor}}
+      template block text
+    {{/permissions-editor}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/adapters/admin-test.js
+++ b/tests/unit/adapters/admin-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:admin', 'Unit | Adapter | admin', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/adapters/collection-test.js
+++ b/tests/unit/adapters/collection-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:collection', 'Unit | Adapter | collection', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/adapters/config-test.js
+++ b/tests/unit/adapters/config-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:config', 'Unit | Adapter | config', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/adapters/experiment-test.js
+++ b/tests/unit/adapters/experiment-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:experiment', 'Unit | Adapter | experiment', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/adapters/session-test.js
+++ b/tests/unit/adapters/session-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('adapter:session', 'Unit | Adapter | session', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let adapter = this.subject();
+  assert.ok(adapter);
+});

--- a/tests/unit/controllers/project-settings-test.js
+++ b/tests/unit/controllers/project-settings-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:project-settings', 'Unit | Controller | project settings', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/mixins/jam-collection-adapter-test.js
+++ b/tests/unit/mixins/jam-collection-adapter-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import JamCollectionAdapterMixin from '../../../mixins/jam-collection-adapter';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | jam collection adapter');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let JamCollectionAdapterObject = Ember.Object.extend(JamCollectionAdapterMixin);
+  let subject = JamCollectionAdapterObject.create();
+  assert.ok(subject);
+});

--- a/tests/unit/mixins/jam-collection-serializer-test.js
+++ b/tests/unit/mixins/jam-collection-serializer-test.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import JamCollectionSerializerMixin from '../../../mixins/jam-collection-serializer';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | jam collection serializer');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let JamCollectionSerializerObject = Ember.Object.extend(JamCollectionSerializerMixin);
+  let subject = JamCollectionSerializerObject.create();
+  assert.ok(subject);
+});

--- a/tests/unit/models/collection-test.js
+++ b/tests/unit/models/collection-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('collection', 'Unit | Model | collection', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/namespace-test.js
+++ b/tests/unit/models/namespace-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('namespace', 'Unit | Model | namespace', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/routes/project-settings-test.js
+++ b/tests/unit/routes/project-settings-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:project-settings', 'Unit | Route | project settings', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/serializers/collection-test.js
+++ b/tests/unit/serializers/collection-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('collection', 'Unit | Serializer | collection', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:collection']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/namespace-test.js
+++ b/tests/unit/serializers/namespace-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('namespace', 'Unit | Serializer | namespace', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:namespace']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-37
## Purpose

We would like to manage permissions for namespaces and collections.

<img width="1412" alt="screen shot 2016-02-02 at 1 04 59 pm" src="https://cloud.githubusercontent.com/assets/2957073/12759165/b72a336e-c9ad-11e5-82da-589fffa90ddb.png">
## Summary of changes
- Move behavior from application adapter/serializer to collection mixins- as we add more types, if doesn't make sense to treat everything like a collection
- Add models for namespaces
- Add scaffold for project settings page, with ability to edit permissions for entire collection
- Improve serializer support for write operations to server (field exclusion etc)
## Sample tests
- Navigate to the project settings page. Add and remove a user (for now, manually enter the entire permissions string)
  - Then try to access any collection using the new user (eg OSF or Jam ID of a different account)
- Change the project-settings page to fetch a single collection (`this.store.find('collection', 'experiments')`). Use that page to edit permissions on the collection.
