### PR TITLE
Get testplayer/ data submission to work with schema validation

### DIFF
--- a/app/routes/testplayer.js
+++ b/app/routes/testplayer.js
@@ -8,7 +8,11 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
             return Ember.RSVP.hash({
                 experiment: experiment,
                 blankSession: self.store.createRecord(experiment.get('sessionCollectionId'), {
-                    experimentId: experiment.id,  // Prefill values before player...
+                    'experimentId': experiment.id,  // Prefill values before player... TODO: Hardcode some for now to avoid validation errors
+                    'experimentVersion': '',
+                    'profileId': 'tester0.prof1',
+                    'profileVersion': '',
+                    'softwareVersion': '',
                 }), // Creates new session but doesn't save to store
             });
         });

--- a/scripts/generate_schemas.js
+++ b/scripts/generate_schemas.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 // h/t: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html
 var ISO_DATE_PATTERN = '^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$';
 
+var PROFILE_ID_PATTERN = new RegExp(/(\w+\.\w+)?/).source; // Profile IDs are <acctShortId>.localIdstring
 var JAM_ID_PATTERN = new RegExp(/\w+\.\w+(\.\w+)?/).source;
 
 


### PR DESCRIPTION
(and fix profileId regex)

Quick fixes to data submission: when schema validation was turned on in the bootstrap script, it broke the ability to send data to the server (because string fields were coming across as null). 

This adds dummy values, and fixes the profileId regex.
