### PR TITLE
Put experiment in fullscreen mode

### DIFF
--- a/scripts/data/experiment.json
+++ b/scripts/data/experiment.json
@@ -270,7 +270,7 @@
      "state": "Active",
      "eligibilityCriteria": "age >= 3 years and age < 6 years",
      "structure": {
-         frames: {
+         "frames": {
              "overview": {
                  "type": "lookit-overview",
                  "title": "Learning from Others: overview",
@@ -285,7 +285,7 @@
                  "captionRight": "The 'Novel object' videos look like this. The same two actors will name new, funny-looking objects with nonsense words.",
                  "summary": "Your child will be asked what he or she thinks each object is called. Once your child response, please repeat his or her answer, but try not to either confirm or correct the answer. For instance, if your child said that the funny-looking object was a blicket, you'd just say \"Okay, a blicket!\" (Sometimes we have trouble hearing or understanding what kids are saying, and parents are their best interpreters.)"
              },
-             sequence: ["overview"]
+             "sequence": ["overview"]
          }
      }
  }]

--- a/scripts/data/experiment.json
+++ b/scripts/data/experiment.json
@@ -7,6 +7,7 @@
     "endDate": "2016-02-04",
     "lastEdited": "2016-02-04",
     "eligibilityCriteria": "age > 3 months and age < 9 months",
+    "displayFullscreen": true,
     "structure": {
         "frames": {
             "pre-consent": {
@@ -112,7 +113,6 @@
                 "kind": "exp-video",
                 "autoforwardOnEnd": true,
                 "autoplay": true,
-                "fullscreen": true,
                 "poster": "big_buck_bunny.jpg",
                 "sources": [
                     {
@@ -158,7 +158,6 @@
                 "kind": "exp-video",
                 "autoforwardOnEnd": false,
                 "autoplay": false,
-                "fullscreen": false,
                 "poster": "oceans.jpg",
                 "sources": [
                     {
@@ -172,7 +171,6 @@
                 "kind": "exp-video",
                 "autoforwardOnEnd": false,
                 "autoplay": true,
-                "fullscreen": false,
                 "poster": "big_buck_bunny.jpg",
                 "sources": [
                     {"type": "video/webm", "src": "physics-clip.webm"}

--- a/scripts/generate_schemas.js
+++ b/scripts/generate_schemas.js
@@ -63,6 +63,10 @@ var EXPERIMENT = {
             "eligibilityCriteria": {
                 "id": "eligibilityCriteria",
                 "type": ["string", "null"]
+            },
+            "displayFullscreen": {
+                "type": "boolean",
+                "default": false
             }
         },
         "required": [


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-98
Companion to: https://github.com/CenterForOpenScience/exp-addons/pull/27
## Purpose

Experiments should be run in fullscreen mode to minimize distractions.

This adds sample data and settings to run the experiment in fullscreen. Following the lookit screenshots, we now display the _browser_, rather than the _video_, as a fullscreen item. (functional change)

For browser support on fullscreen API, see: http://caniuse.com/#search=fullscreen

A regular element in fullscreen mode:
![screen shot 2016-03-02 at 12 06 22 pm](https://cloud.githubusercontent.com/assets/2957073/13468275/e35d2d14-e06f-11e5-9b3a-841a51e1e7c4.png)

A regular element not in fullscreen mode:
![screen shot 2016-03-02 at 12 06 41 pm](https://cloud.githubusercontent.com/assets/2957073/13468297/f4b1e582-e06f-11e5-9866-ad5f908a1b0b.png)

A video element in fullscreen mode (note that the page, not the video, is fullscreen. I can't tell if this is consistent with the existing screenshots or not)
![screen shot 2016-03-02 at 12 08 19 pm](https://cloud.githubusercontent.com/assets/2957073/13468306/f87d3f4a-e06f-11e5-95eb-9d136a50a8cc.png)
## Summary of changes
- Add configurable mixin and styles that can be used to provide fullscreen support to any component
- Use mixin for the overall experiment player
- Add a page button to return to fullscreen
- Remove separate fullscreen implementation from video frame
- Update sample data
## TODO
- [ ] Functional review
- [x] Clean up erratic capitalizations of fullScreen vs fullscreen
