### PR TITLE
Add a very simple random-shuffle choice frame

### DIFF
--- a/app/components/export-tool.js
+++ b/app/components/export-tool.js
@@ -3,8 +3,8 @@ import Ember from 'ember';
 export default Ember.Component.extend({
     attributeBindings: ['data', 'mappingFunction'],
     dataFormat: 'JSON',
-    dataFormats: [ 'JSON', 
-        'CSV' 
+    dataFormats: [ 'JSON',
+        'CSV'
     ],
     defaultMappingFunction: function (model) {
         return model._internalModel._data;
@@ -16,22 +16,22 @@ export default Ember.Component.extend({
             var mappingFunction = this.get('mappingFunction');
             if (Ember.isPresent(dataArray) && Ember.isPresent(mappingFunction)) {
                 var mapped = dataArray.map(mappingFunction);
-                return this.convertToFormat(mapped, dataFormat); 
+                return this.convertToFormat(mapped, dataFormat);
             } else if (Ember.isPresent(dataArray)) {
                 var mapped = dataArray.map(this.get('defaultMappingFunction'));
-                return this.convertToFormat(mapped, dataFormat); 
+                return this.convertToFormat(mapped, dataFormat);
             } else {
                 return null;
             }
-        }, 
+        },
         set(_, value) {
             this.set('processedData', value);
             return value;
         }
     }),
     convertToFormat: function (dataArray, format) {
-        if (format === "JSON") {
-            return JSON.stringify(dataArray, undefined, 4); 
+        if (format === 'JSON') {
+            return JSON.stringify(dataArray, undefined, 4);
         } else {
             var array = typeof dataArray !== 'object' ? JSON.parse(dataArray) : dataArray;
             var str = '';
@@ -40,8 +40,7 @@ export default Ember.Component.extend({
                 var line = '';
                 if (typeof array[i] === 'object') {
                     for (var index in array[i]) {
-                        if (line !== '') line += ','
-
+                        if (line !== '') {line += ',';}
                         line += array[i][index];
                     }
                 } else {
@@ -54,13 +53,13 @@ export default Ember.Component.extend({
     },
     actions: {
         downloadFile: function () {
-            var blob = new Blob([this.get('processedData')], {type: "text/plain;charset=utf-8"});
+            var blob = new Blob([this.get('processedData')], {type: 'text/plain;charset=utf-8'});
             var extension = this.get('dataFormat').toLowerCase();
-            saveAs(blob, "data." + extension);
+            saveAs(blob, 'data.' + extension);
         },
         selectDataFormat: function(dataFormat) {
           this.set('dataFormat', dataFormat);
         }
     }
-    
+
 });

--- a/scripts/data/experiment.json
+++ b/scripts/data/experiment.json
@@ -47,6 +47,14 @@
                     "maybe-soundcheck"
                 ]
             },
+            "one-shuffle": {
+                "kind": "choice",
+                "sampler": "shuffle",
+                "options": [
+                    "maybe-consent",
+                    "maybe-soundcheck"
+                ]
+            },
             "maybe-consent": {
                 "kind": "exp-consent",
                 "title": "Just checking",
@@ -186,7 +194,7 @@
         "sequence": [
             "pre-consent", "first-soundcheck", "one-randomizer",
             "second-randomizer", "first-video", "second-audio",
-            "second-video", "third-video", "post-consent"
+            "second-video", "third-video", "one-shuffle", "post-consent"
         ]
     }
 } , {


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-105
Companion to 
## Purpose

Preliminary instructions in design doc suggest they will want some way to display different arrangements of frames. This adds a new `shuffle` sample to the `choice` frame type.

When used, rather than choosing one option, it will return all options (but in a randomly chosen order)

Further complexity can be added later depending on requirements feedback with client.
## Summary of changes
- Add new sampler type
- Add sample data
- Resolve a pile of jshint errors so that linting will actually remain useful
