### PR TITLE
UI to maintain list of authorize project admins

### DIFF
--- a/app/components/permissions-editor.js
+++ b/app/components/permissions-editor.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {adminPattern} from  '../utils/patterns';
 
 // FIXME: Known bug in original- if the server save request fails, the value will appear to have been added until page reloaded.
 //  (need to catch and handle errors)
@@ -9,21 +10,35 @@ let PermissionsEditor = Ember.Component.extend({
     newPermissionLevel: 'ADMIN',
     newPermissionSelector: '',
 
+    usersList: Ember.computed('permissions', function() {
+        var permissions = this.get('permissions');
+
+        // Assumption: all properties passed into this page will match admin pattern
+        return Object.getOwnPropertyNames(permissions).map(function(key){
+            return adminPattern.exec(key)[1];
+        });
+    }),
+
     actions: {
         addPermission() {
             var userId = this.get('newUserId');
 
             this.permissions[`user-osf-${userId}`] = this.get('newPermissionLevel');
             this.set('newUserId', '');
-            this.rerender();
             this.sendAction('onchange', this.get('permissions'));
+            this.set('permissions', this.permissions);
+            this.rerender();
+
         },
 
         removePermission(userId) {
             var selector = `user-osf-${userId}`;
-            delete this.permissions[selector];
+            var permissions = this.get('permissions');
+
+            delete permissions[selector];
+            this.sendAction('onchange', permissions);
+            this.set('permissions', permissions);
             this.rerender();
-            this.sendAction('onchange', this.get('permissions'));
         }
     }
 });

--- a/app/components/permissions-editor.js
+++ b/app/components/permissions-editor.js
@@ -22,18 +22,18 @@ let PermissionsEditor = Ember.Component.extend({
     actions: {
         addPermission() {
             var userId = this.get('newUserId');
-
-            this.permissions[`user-osf-${userId}`] = this.get('newPermissionLevel');
+            var permissions = Ember.copy(this.get('permissions'));
+            permissions[`user-osf-${userId}`] = this.get('newPermissionLevel');
             this.set('newUserId', '');
-            this.sendAction('onchange', this.get('permissions'));
-            this.set('permissions', this.permissions);
+            this.sendAction('onchange', permissions);
+            this.set('permissions', permissions);
             this.rerender();
 
         },
 
         removePermission(userId) {
             var selector = `user-osf-${userId}`;
-            var permissions = this.get('permissions');
+            var permissions = Ember.copy(this.get('permissions'));
 
             delete permissions[selector];
             this.sendAction('onchange', permissions);

--- a/app/components/permissions-editor.js
+++ b/app/components/permissions-editor.js
@@ -10,30 +10,33 @@ let PermissionsEditor = Ember.Component.extend({
         'READ',
         'UPDATE',
         'DELETE',
-        'ADMIN',
+        'ADMIN'
     ],
 
-    newPermissionLevel: 'CREATE',
+    newPermissionLevel: 'ADMIN',
     newPermissionSelector: '',
 
     actions: {
         addPermission() {
-            this.permissions[this.get('newPermissionSelector')] = this.get('newPermissionLevel');
-            this.set('newPermissionSelector', '');
+            var userId = this.get('newUserId');
+
+            this.permissions[`user-osf-${userId}`] = this.get('newPermissionLevel');
+            this.set('newUserId', '');
             this.rerender();
-            this.get('onchange')(this.get('permissions'));
+            this.sendAction('onchange', this.get('permissions'));
         },
 
-        removePermission(selector) {
+        removePermission(userId) {  // TODO: use same template as above
+            var selector = `user-osf-${userId}`;
             delete this.permissions[selector];
             this.rerender();
-            this.get('onchange')(this.get('permissions'));
-        },
+            this.sendAction('onchange', this.get('permissions'));
+        }
     }
 });
 
 PermissionsEditor.reopenClass({
-    positionalParams: ['permissions'],
+    positionalParams: ['permissions']
 });
 
 

--- a/app/components/permissions-editor.js
+++ b/app/components/permissions-editor.js
@@ -5,13 +5,6 @@ import Ember from 'ember';
 let PermissionsEditor = Ember.Component.extend({
     tagName: 'table',
     classNames: ['table'],
-    permissionLevels: [
-        'CREATE',
-        'READ',
-        'UPDATE',
-        'DELETE',
-        'ADMIN'
-    ],
 
     newPermissionLevel: 'ADMIN',
     newPermissionSelector: '',
@@ -26,7 +19,7 @@ let PermissionsEditor = Ember.Component.extend({
             this.sendAction('onchange', this.get('permissions'));
         },
 
-        removePermission(userId) {  // TODO: use same template as above
+        removePermission(userId) {
             var selector = `user-osf-${userId}`;
             delete this.permissions[selector];
             this.rerender();

--- a/app/controllers/project-settings.js
+++ b/app/controllers/project-settings.js
@@ -3,6 +3,8 @@ import {adminPattern} from  '../utils/patterns';
 
 
 export default Ember.Controller.extend({
+    breadCrumb: 'Project configuration',
+
     filteredPermissions: Ember.computed('model', function() {
         var permissions = this.get('model.permissions');
         var users = {};

--- a/app/controllers/project-settings.js
+++ b/app/controllers/project-settings.js
@@ -1,9 +1,39 @@
 import Ember from 'ember';
 
+// Admin users are those authenticated via OSF
+var adminPattern = new RegExp(/^user-osf-(\w+|\*)$/);
+
 export default Ember.Controller.extend({
+    filteredPermissions: Ember.computed('model', function() {
+        var permissions = this.get('model.permissions');
+        var users = {};
+        var system = {};
+        for (let k of Object.getOwnPropertyNames(permissions)) {
+            var dest = adminPattern.test(k) ? users : system;
+            dest[k] = permissions[k];
+        }
+        return [users, system];
+    }),
+
+    /* Return permissions strings that correspond to admin users (those who log in via OSF) */
+    userPermissions:  Ember.computed('filteredPermissions', function() {
+        var filtered = this.get('filteredPermissions');
+        return filtered[0];
+    }),
+
+    /* Return permissions strings that do not match OSF users */
+    systemPermissions:  Ember.computed('filteredPermissions', function() {
+        var filtered = this.get('filteredPermissions');
+        return filtered[1];
+    }),
+
     actions: {
         permissionsUpdated(permissions) {
-            this.set('model.permissions', permissions);
+            // Save updated permissions, and avoid overwriting system-level permissions not displayed to the user
+
+            var payload = Object.assign({}, permissions, this.get('systemPermissions'));
+            console.log('permissions', this.get('userPermissions'), this.get('systemPermissions'), payload);
+            this.set('model.permissions', payload);
             this.get('model').save();
         }
     }

--- a/app/controllers/project-settings.js
+++ b/app/controllers/project-settings.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
+import {adminPattern} from  '../utils/patterns';
 
-// Admin users are those authenticated via OSF
-var adminPattern = new RegExp(/^user-osf-(\w+|\*)$/);
 
 export default Ember.Controller.extend({
     filteredPermissions: Ember.computed('model', function() {
@@ -16,10 +15,11 @@ export default Ember.Controller.extend({
     }),
 
     /* Return permissions strings that correspond to admin users (those who log in via OSF) */
-    userPermissions:  Ember.computed('filteredPermissions', function() {
+    _userPermissions:  Ember.computed('filteredPermissions', function() {
         var filtered = this.get('filteredPermissions');
         return filtered[0];
     }),
+    userPermissions: Ember.computed.readOnly('_userPermissions'), // TODO: is this necessary?
 
     /* Return permissions strings that do not match OSF users */
     systemPermissions:  Ember.computed('filteredPermissions', function() {
@@ -32,7 +32,6 @@ export default Ember.Controller.extend({
             // Save updated permissions, and avoid overwriting system-level permissions not displayed to the user
 
             var payload = Object.assign({}, permissions, this.get('systemPermissions'));
-            console.log('permissions', this.get('userPermissions'), this.get('systemPermissions'), payload);
             this.set('model.permissions', payload);
             this.get('model').save();
         }

--- a/app/templates/components/permissions-editor.hbs
+++ b/app/templates/components/permissions-editor.hbs
@@ -1,7 +1,6 @@
 <thead>
   <tr>
     <th>User Selector</th>
-    <th>Permission Level</th>
     <th width="5%">Add / remove</th>
   </tr>
 </thead>
@@ -9,7 +8,6 @@
 {{#each-in permissions as |user-selector permission|}}
   <tr>
     <td>{{user-selector}}</td>
-    <td>{{permission}}</td>
     <td>
       <button {{action 'removePermission' user-selector}} class="btn btn-xs bg-red">
         <i class="fa fa-remove"></i>
@@ -20,13 +18,6 @@
   <tr>
     <td>
       {{input value=newUserId type="text" class="form-control"}}
-    </td>
-    <td>
-      <select onchange={{action (mut newPermissionLevel) value="target.value"}}>
-        {{#each permissionLevels as |permission|}}
-          <option>{{permission}}</option>
-        {{/each}}
-      </select>
     </td>
     <td>
       <button {{action 'addPermission'}} class="btn btn-xs bg-black">

--- a/app/templates/components/permissions-editor.hbs
+++ b/app/templates/components/permissions-editor.hbs
@@ -19,7 +19,7 @@
 {{/each-in}}
   <tr>
     <td>
-      {{input value=newPermissionSelector type="text" class="form-control"}}
+      {{input value=newUserId type="text" class="form-control"}}
     </td>
     <td>
       <select onchange={{action (mut newPermissionLevel) value="target.value"}}>

--- a/app/templates/components/permissions-editor.hbs
+++ b/app/templates/components/permissions-editor.hbs
@@ -9,7 +9,7 @@
   <tr>
     <td>{{userId}}</td>
     <td>
-      <button {{action 'removePermission' userId}} class="btn btn-xs bg-red">
+      <button {{action 'removePermission' userId}} class="btn btn-xs btn-danger">
         <i class="fa fa-remove"></i>
       </button>
     </td>
@@ -20,7 +20,7 @@
       {{input value=newUserId type="text" class="form-control"}}
     </td>
     <td>
-      <button {{action 'addPermission'}} class="btn btn-xs bg-black">
+      <button {{action 'addPermission'}} class="btn btn-xs btn-success">
         <i class="fa fa-plus"></i>
       </button>
     </td>

--- a/app/templates/components/permissions-editor.hbs
+++ b/app/templates/components/permissions-editor.hbs
@@ -5,16 +5,16 @@
   </tr>
 </thead>
 <tbody>
-{{#each-in permissions as |user-selector permission|}}
+{{#each usersList as |userId|}}
   <tr>
-    <td>{{user-selector}}</td>
+    <td>{{userId}}</td>
     <td>
-      <button {{action 'removePermission' user-selector}} class="btn btn-xs bg-red">
+      <button {{action 'removePermission' userId}} class="btn btn-xs bg-red">
         <i class="fa fa-remove"></i>
       </button>
     </td>
   </tr>
-{{/each-in}}
+{{/each}}
   <tr>
     <td>
       {{input value=newUserId type="text" class="form-control"}}

--- a/app/templates/project-settings.hbs
+++ b/app/templates/project-settings.hbs
@@ -5,6 +5,6 @@
 <h2>Add administrator to project</h2>
 <p>Enter the permissions string for the desired user, one per line.</p>
 
-{{permissions-editor model.permissions onchange=(action 'permissionsUpdated')}}
+{{permissions-editor userPermissions onchange=(action 'permissionsUpdated')}}
 
 {{outlet}}

--- a/app/utils/patterns.js
+++ b/app/utils/patterns.js
@@ -1,0 +1,10 @@
+/*
+ Regexes and string templates reused throughout the application
+*/
+
+
+// Admin users are those authenticated via OSF
+var adminPattern = new RegExp(/^user-osf-(\w+|\*)$/);
+
+export {adminPattern};
+

--- a/tests/unit/utils/patterns-test.js
+++ b/tests/unit/utils/patterns-test.js
@@ -1,0 +1,10 @@
+import patterns from 'experimenter/utils/patterns';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | patterns');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = patterns();
+  assert.ok(result);
+});


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-116
## Purpose

All project admins to add other admins.

We define an "admin" as someone who is logged in to the application using an OSF account with a known user ID. This provides a mechanism to give namespace-level permissions (ADMIN level) to a specified OSF user ID.
## Requirements
- [x] The page should only display OSF users. If other accounts (like system) have privileges, don't display those on the list
  - [x] When the revised permissions are saved, be sure to include system permissions. Don't silently drop them by accident.
- [x] The page should update correctly when a user is added/remove
- [x] Create "add" and "remove" buttons that automatically convert the OSF user ID string (`abcde`) into a full permission string (`user-osf-abcde`)
- [x] All OSF IDs should be added as ADMIN level automatically.
## Samples

<img width="1186" alt="screen shot 2016-03-08 at 3 48 43 pm" src="https://cloud.githubusercontent.com/assets/2957073/13615870/5980c3fa-e545-11e5-8433-78c6d5640607.png">

Payload sent to server when adding user `12345`: (just the `permissions` part)

```
"permissions": {"user-osf-7bauz": "ADMIN", "system-system-system": "ADMIN", "user-osf-*": "ADMIN", "user-osf-12345": "ADMIN", "jam-experimenter:sys-root": "ADMIN"}
```

And when removing that user: (just the `permissions` part)

```
"permissions": {"user-osf-7bauz": "ADMIN", "system-system-system": "ADMIN", "user-osf-*": "ADMIN", "jam-experimenter:sys-root": "ADMIN"}
```
