### PR TITLE
Control field serialization via whitelist

### DIFF
--- a/app/routes/experiments/info/results.js
+++ b/app/routes/experiments/info/results.js
@@ -7,5 +7,21 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         let experiment = this.modelFor('experiments/info');
         return this.store.query(experiment.get('sessionCollectionId'),
             {'filter[completed]': 1});
+    },
+
+    setupController(controller, model) {
+        this._super(...arguments);
+        // Create a whitelist controlling how session fields will be serialized
+        controller.set('serializeFields',
+            [
+                {field: 'profileId', transform: (value) => value.split ? value.split('.')[1] : value}, // given acct.profId format, strip off the account ID part
+                'sequence',
+                'expData',
+                'experimentVersion',
+                'softwareVersion',
+                'createdOn',
+                'modifiedOn'
+            ]);
+
     }
 });

--- a/app/styles/components/export-tool.scss
+++ b/app/styles/components/export-tool.scss
@@ -2,18 +2,22 @@
     height: 100%;
     text-align: center;
 }
+
 .export-tool-textarea-container {
     height: 70%;
 }
+
 .export-tool-select {
     min-width: 70px;
 }
+
 .export-tool-textarea {
     width: 90%;
     max-width: 90%;
+    min-height: 250px;
     background-color: black;
     color: white;
     -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
-    -moz-box-sizing: border-box;    /* Firefox, other Gecko */
+    -moz-box-sizing: border-box; /* Firefox, other Gecko */
     box-sizing: border-box;
 }

--- a/app/templates/components/experiment-results.hbs
+++ b/app/templates/components/experiment-results.hbs
@@ -7,11 +7,11 @@
 <div class="tab-content">
   <div id="participantData" class="tab-pane fade in active">
     <h3>Participant Data</h3>
-    {{participant-data sessions=sessions}}
+    {{participant-data sessions=sessions serializeFields=serializeFields}}
   </div>
   <div id="allData" class="tab-pane fade">
     <h3>All Data</h3>
-    {{export-tool data=sessions}}
+    {{export-tool data=sessions fieldWhitelist=serializeFields}}
   </div>
   <div id="allAttachments" class="tab-pane fade">
     {{all-attachments sessions=sessions}}

--- a/app/templates/components/participant-data.hbs
+++ b/app/templates/components/participant-data.hbs
@@ -15,9 +15,9 @@
       {{/each}}
     </tbody>
   </table>
-</div> 
+</div>
 <div class="col-md-6">
-  {{export-tool data=participantSession}}
+  {{export-tool data=participantSession fieldWhitelist=serializeFields}}
   <div class="row">Attachments</div>
   {{attachment-download showDate=false}}
 </div>

--- a/app/templates/experiments/info/results.hbs
+++ b/app/templates/experiments/info/results.hbs
@@ -1,2 +1,2 @@
 <h2>Responses</h2>
-{{experiment-results sessions=model}}
+{{experiment-results sessions=model serializeFields=serializeFields}}


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/LEI-120
Companion: None
## Purpose

Right now the serialized session representation includes a creator field, which is a potentially identifying piece of information. We would like to be able to control how results (esp sessions) are serialized to remove certain fields.

In order to best protect privacy, we serialize using a whitelist. Fields not listed are not serialized.
## Summary of changes

Add a new `serializeFields` property to the route controller, which whitelists only a select handful of session fields to be serialized.

Allow the export tool to accept a `fieldWhitelist` property that handles serialization. This whitelist is an array that can accept entries of two forms- a field name as a string, or an object of form `{field:name, transform: somefunc}`
## Design note

Given a profile ID of form `accountId.profUniqueString`, this strips off the account ID. Therefore, it assumes that profile IDs will be unique. This assumption [appears to be valid](https://github.com/CenterForOpenScience/lookit/blob/5ad08fb64651399c11f26f0c0d9636ee8b1ed6c7/app/controllers/my/children.js#L15-L15) for Lookit.
## Sample output/ Notes for testers

Sample data below is taken from a clean run of the bootstrap script, visiting http://localhost:4200/experiments/experimenter.experiments.test0/results
Without the whitelist:

```
[
    {
        "sequence": [],
        "softwareVersion": "0.0.1",
        "expData": {},
        "profileId": "tester1.prof1",
        "profileVersion": "abcdefgab",
        "experimentId": "experimenter.experiments.test0",
        "experimentVersion": "qwertyuiop",
        "completed": true,
        "feedback": "OMG, so cute",
        "hasReadFeedback": true,
        "createdOn": "2016-03-10T10:35:02.748Z",
        "modifiedOn": "2016-03-10T10:35:02.748Z",
        "createdBy": "jam-experimenter:sys-root",
        "modifiedBy": "jam-experimenter:sys-root"
    }
]
```

With the whitelist:

```
[
    {
        "profileId": "prof1",
        "sequence": [],
        "expData": {},
        "experimentVersion": "qwertyuiop",
        "softwareVersion": "0.0.1",
        "createdOn": "2016-03-10T10:35:02.748Z",
        "modifiedOn": "2016-03-10T10:35:02.748Z"
    }
]
```
