### PR TITLE
Prevent writing to session collection when experiment is inactive

### DIFF
--- a/app/components/experiment-detail.js
+++ b/app/components/experiment-detail.js
@@ -1,5 +1,8 @@
 import Ember from 'ember';
 
+import {permissionCreateForAccounts} from 'exp-models/utils/constants';
+
+
 export default Ember.Component.extend({
     experiment: null,
     sessions: null,
@@ -19,21 +22,30 @@ export default Ember.Component.extend({
             var exp = this.get('experiment');
             exp.set('state', exp.ARCHIVED);
             exp.save().then(() => {
-                this.get('toast.info')('Experiment stopped successfully.');
+                return this.get('store').findRecord('collection', exp.get('sessionCollectionId')).then((collection) => {
+                    collection.set('permissions', {});
+                    return collection.save();
+                }).then(() => this.get('toast.info')('Experiment stopped successfully.'));
             });
         },
         start: function() {
             var exp = this.get('experiment');
             exp.set('state', exp.ACTIVE);
             exp.save().then(() => {
-                this.toast.info('Experiment started successfully.');
+                return this.get('store').findRecord('collection', exp.get('sessionCollectionId')).then((collection) => {
+                    collection.set('permissions', permissionCreateForAccounts);
+                    return collection.save();
+                }).then(() => this.get('toast.info')('Experiment started successfully.'));
             });
         },
         delete: function() {
             var exp = this.get('experiment');
             exp.set('state', exp.DELETED);
             exp.save().then(() => {
-                this.sendAction('onDelete');
+                return this.get('store').findRecord('collection', exp.get('sessionCollectionId')).then((collection) => {
+                    collection.set('permissions', {});
+                    return collection.save();
+                }).then(() => this.sendAction('onDelete'));
             });
         },
         clone: function() {

--- a/scripts/data/experiment.json
+++ b/scripts/data/experiment.json
@@ -6,6 +6,7 @@
     "beginDate": "2016-02-03",
     "endDate": "2016-02-04",
     "lastEdited": "2016-02-04",
+    "exitUrl": "http://localhost:4200",
     "eligibilityCriteria": "age > 3 months and age < 9 months",
     "displayFullscreen": true,
     "thumbnailId": "experimenter.thumbnails.test0-thumb",
@@ -202,9 +203,8 @@
     "state": "Active",
     "eligibilityCriteria": "age >= 9 months and age < 2 years",
     "duration": "Ten minutes",
-    "whatHappens": "First your child will see two actors naming familiar objects. Sometimes they're correct, sometimes they're not. Then we'll show the same actors naming unfamiliar objects and ask your child some questions about which answers he or she trusts.",
     "purpose": "How children track and use information about reliability.",
-    "exitUrl": "http://localhost:4201",
+    "exitUrl": "http://localhost:4200",
     "thumbnailId": "experimenter.thumbnails.demo-thumb",
     "structure": {
         "frames": {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-122
Companion to: 
## Purpose

When an admin stops an experiment, remove the permissions that allow users to submit new records. 
## Summary of changes

For now this manually changes each individual point where an experiment state is changed. This is very fragile and does not encompass use cases like activating the experiment by changing raw json in the edit route.

A better way in the future would be to create an observer that only changes session when isActive changes AND the record is saved, but in initial experimentation I had trouble with this compound condition. The current reliance on boilerplate could become problematic in the future.
## Testing notes

Will need to test this in lookit, since the preview route in experimenter no longer saves data.
