### PR TITLE
Anonymize profile IDs displayed in result summary table

### DIFF
--- a/app/components/export-tool.js
+++ b/app/components/export-tool.js
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
     fieldWhitelist: null, // Optionally provide a whitelist of either ["fieldname"] or [{field: name, transform: function}] objects to control individual field serialization
 
     defaultMappingFunction: function (model) {
-        var data = model._internalModel._data;
+        var data = model._internalModel._data;  // Note: will not include results of computed properties
         var whitelist = this.get('fieldWhitelist');
         if (!whitelist) {
             return data;

--- a/app/templates/components/participant-data.hbs
+++ b/app/templates/components/participant-data.hbs
@@ -9,7 +9,7 @@
     <tbody>
       {{#each sortedSessions as |session|}}
         <tr class="clickable-row" {{action 'updateData' session}}>
-          <td>{{session.profileId}}</td>
+          <td>{{session.anonProfileId}}</td>
           <td>{{moment-format session.createdOn 'MM/DD/YYYY'}}</td>
         </tr>
       {{/each}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-149
Companion to: https://github.com/CenterForOpenScience/exp-addons/pull/61
## Purpose

Profile/participant IDs, as displayed on the `/results` page "participant data" tab, are of the form `acctId.random`. We want to strip the account prefix when it is displayed in the summary table in order to better anonymize the data.
## Summary of changes

<img width="1159" alt="screen shot 2016-03-14 at 7 08 36 pm" src="https://cloud.githubusercontent.com/assets/2957073/13762874/5587e792-ea18-11e5-8322-daa2d0b3c4a3.png">
## Testing notes

It seems that the internal _data we use in export tool doesn't have access to computed properties, so there's some redundancy; we can DRY the transform functions later
