### PR TITLE
[fix] Experiment editor errors

### DIFF
--- a/app/components/ace-editor/component.js
+++ b/app/components/ace-editor/component.js
@@ -8,13 +8,13 @@ export default Ember.Component.extend({
     _initValue: null,
     isValidSyntax: true,
 
-    ctx: function() {
+    ctx: Ember.computed('isValidSyntax', function () {
         return {
             submit: this.get('actions.onClick').bind(this),
             validSyntax: this.get('isValidSyntax'),
             notValidSyntax: !this.get('isValidSyntax')
         };
-    }.property('isValidSyntax'),
+    }),
 
     didInsertElement() {
         this.set('_initValue', this.get('value') || '{}');
@@ -34,6 +34,7 @@ export default Ember.Component.extend({
     _onChange(e, session) {
         this.set('value', this.editor.getSession().getValue());
     },
+
     _onChangeAnnotation(e, session) {
         if (session.getValue().length < 1) {
             this.set('isValidSyntax', false);
@@ -41,20 +42,22 @@ export default Ember.Component.extend({
 
         let annotations = session.getAnnotations();
 
-        for(var i = 0; i < annotations.length; i++) {
+        for (var i = 0; i < annotations.length; i++) {
             if (annotations[i].type === 'error') {
                 this.set('isValidSyntax', false);
             }
         }
         this.set('isValidSyntax', true);
     },
-    valueChanged: function() {
+
+    valueChanged: Ember.observer('value', function () {
         if (!this.get('value')) {
             this.editor.getSession().setValue('');
         } else if (this.editor.getSession().getValue() !== this.get('value')) {
             this.editor.getSession().setValue(this.get('value'));
         }
-    }.observes('value'),
+    }),
+
     actions: {
         onClick() {
             this.sendAction('submit', this.get('editor'));

--- a/app/controllers/experiments/info/edit.js
+++ b/app/controllers/experiments/info/edit.js
@@ -77,7 +77,15 @@ export default Ember.Controller.extend({
 
     actions: {
         submit(editor) {
-            let parsed = JSON.parse(editor.getValue());
+            let parsed;
+            try {
+                parsed = JSON.parse(editor.getValue());
+            } catch (e) {
+                console.log('Syntax error in JSON payload: ', e);
+                this.toast.error('Please check the experiment for syntax errors before saving');
+                return;
+            }
+
             let schema = Object.assign({}, SESSIONSCHEMA);
 
             try {
@@ -87,7 +95,7 @@ export default Ember.Controller.extend({
                     additionalProperties: false
                 };
             } catch (e) {
-                this.toast.error('Error Parsing Experiment: ' + e);
+                this.toast.error('Could not understand this experiment definition: ' + e);
                 return;
             }
 

--- a/app/controllers/experiments/info/edit.js
+++ b/app/controllers/experiments/info/edit.js
@@ -95,7 +95,8 @@ export default Ember.Controller.extend({
                     additionalProperties: false
                 };
             } catch (e) {
-                this.toast.error('Could not understand this experiment definition: ' + e);
+                console.log('Could not validate incomplete or incorrect experiment definition: ', e);
+                this.toast.error('Please check experiment definition for missing or incomplete fields before saving');
                 return;
             }
 

--- a/app/controllers/experiments/info/edit.js
+++ b/app/controllers/experiments/info/edit.js
@@ -71,9 +71,9 @@ export default Ember.Controller.extend({
     breadCrumb: 'Edit',
     toast: Ember.inject.service('toast'),
 
-    experimentJson: function() {
+    experimentJson: Ember.computed('model', function () {
         return JSON.stringify(this.get('model.structure'), null, 4);
-    }.property('model'),
+    }),
 
     actions: {
         submit(editor) {
@@ -86,7 +86,7 @@ export default Ember.Controller.extend({
                     patternProperties: createSchema(getOwner(this), parsed.sequence, parsed.frames),
                     additionalProperties: false
                 };
-            } catch(e) {
+            } catch (e) {
                 this.toast.error('Error Parsing Experiment: ' + e);
                 return;
             }
@@ -97,7 +97,9 @@ export default Ember.Controller.extend({
             //But calling get returns the value returned by set....
             this.get('model.schema', schema).then(() => this.get('model').save())
                 .then(() => this.toast.success('Experiment updated'))
-                .catch(() => this.toast.error('The server refused to save the data, likely due to a schema error'));
+                .catch(() => this.toast.error('The server refused to save the data, likely due to a schema error'))
+                .then(() => this.transitionToRoute('experiments.info.index', this.get('model.id')))
+                .catch(() => this.toast.error('Error: could not find the summary page for this experiment'));
         }
     }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-157
Companion to: None
## Purpose

The experiment editor fails silently or gives the wrong error message when saving invalid JSON. 

This adds toast (growl-style) notifications as appropriate.
## Summary of changes
- Add route transition after save
- Clarify error messages
- Minor syntax cleanup (see references in commit message)
## Testing notes

Tested the following error cases:
- Invalid JSON syntax, eg remove a quotation mark (returns syntax toast error)
- Invalid schema due to incorrect or missing required field (deleted the "sequence" field entirely) - returns experiment definition syntax error + console log with details
- After clicking save, should redirect to experiment detail page
