### PR TITLE
Fix malformed ULRLs/ adapter error issues

### DIFF
--- a/app/controllers/experiments/info/edit.js
+++ b/app/controllers/experiments/info/edit.js
@@ -105,10 +105,12 @@ export default Ember.Controller.extend({
             //HACK set just returns the value passed in, not the value returned by the underlying set
             //But calling get returns the value returned by set....
             this.get('model.schema', schema).then(() => this.get('model').save())
-                .then(() => this.toast.success('Experiment updated'))
-                .catch(() => this.toast.error('The server refused to save the data, likely due to a schema error'))
-                .then(() => this.transitionToRoute('experiments.info.index', this.get('model.id')))
-                .catch(() => this.toast.error('Error: could not find the summary page for this experiment'));
+                .then(() => {
+                    this.toast.success('Experiment updated');
+                    return this.transitionToRoute('experiments.info.index', this.get('model.id'));
+                })
+                .catch(() => this.toast.error('The server refused to save the data, likely due to a schema error'));
+
         }
     }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-159
Companion to: https://github.com/CenterForOpenScience/exp-addons/pull/64
## Purpose

Fix issues saving models due to malformed URLs (caused by missing parameter in `ApplicationAdapter`)

This bug also revealed an issue where the edit page transitioned after handling a server error. (if the data wasn't saved, it shouldn't transition) The fix was to remove an unlikely error message and rearrange the promise chain.
## Testing notes

Before the change, saving experiments in editor failed, and cloning an experiment lead to various AdapterErrors being dumped to the console.

Tested this (with successful functionality) on experiment list, demo, and edit pages. Also tried project settings page, then logged out and went through again.

If there are regressions, there should be evidence via adapter errors and malformed urls.
