### PR TITLE
Fix issue that prevented `/results` page from loading

### DIFF
--- a/app/components/export-tool.js
+++ b/app/components/export-tool.js
@@ -35,7 +35,10 @@ export default Ember.Component.extend({
             if (data.toArray) {
                 data = data.toArray();
             }
-            var dataArray = data.map(squash.bind(this));
+            var dataArray = [];
+            data.forEach((item /*, index, array*/) => { // Ensure that mapping function doesn't treat *index* as the optional recursive *prefix* parameter
+                dataArray.push(squash.apply(this, [item]));
+            });
 
             var dataFormat = this.get('dataFormat');
             var mappingFunction = this.get('mappingFunction') || ((x) => x);

--- a/scripts/data/sessiontest0.json
+++ b/scripts/data/sessiontest0.json
@@ -6,7 +6,7 @@
     "completed": true,
     "sequence": [],
     "expData": {},
-    "feedback": "OMG, so cute",
+    "feedback": "",
     "hasReadFeedback": true
 }, {
     "id": "session1b",
@@ -16,7 +16,7 @@
     "completed": true,
     "sequence": [],
     "expData": {},
-    "feedback": "OMG, so cute",
+    "feedback": "feedback on second",
     "hasReadFeedback": false
 }, {
     "id": "session2a",
@@ -26,7 +26,7 @@
     "completed": true,
     "sequence": [],
     "expData": {},
-    "feedback": "OMG, so cute",
+    "feedback": "feedback on third",
     "hasReadFeedback": true
 }, {
     "id": "session2b",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-162
Companion to: None
## Purpose

Fix an issue that prevented the results page from loading due to JS console error, 
`TypeError: Cannot read property 'split' of undefined`
## Summary of changes

Make sure that mapping function isn't accidentally given extra arguments.
## Testing notes

Problem occurred for any page with >1 session, such as http://localhost:4200/experiments/test0/results

Origin of issue: the mapping function expects a signature of `item, index, array`, and the index was being used as the optional prefix parameter of `squash(item, prefix)`. 0 is falsy, but other numbers are not.

Before the change, the squashed results array was:

```
"[
    {
        "sequence": [],
        "profileId": "prof1",
        "experimentId": "test0",
        "experimentVersion": "qwertyuiop",
        "completed": true,
        "feedback": "OMG, so cute",
        "hasReadFeedback": true
    },
    {
        "1.sequence": [],
        "1.profileId": "tester1.prof1",
        "1.experimentId": "test0",
        "1.experimentVersion": "qwertyuiop",
        "1.completed": true,
        "1.feedback": "OMG, so cute",
        "1.hasReadFeedback": false
    },
    {
        "2.sequence": [],
        "2.profileId": "tester1.prof1",
        "2.experimentId": "test0",
        "2.experimentVersion": "qwertyuiop",
        "2.completed": true,
        "2.feedback": "OMG, so cute",
        "2.hasReadFeedback": true
    }
]"
```

After:

```
"[
    {
        "sequence": [],
        "profileId": "prof1",
        "experimentId": "test0",
        "experimentVersion": "qwertyuiop",
        "completed": true,
        "feedback": "",
        "hasReadFeedback": true
    },
    {
        "sequence": [],
        "profileId": "prof1",
        "experimentId": "test0",
        "experimentVersion": "qwertyuiop",
        "completed": true,
        "feedback": "feedback on second",
        "hasReadFeedback": false
    },
    {
        "sequence": [],
        "profileId": "prof1",
        "experimentId": "test0",
        "experimentVersion": "qwertyuiop",
        "completed": true,
        "feedback": "feedback on third",
        "hasReadFeedback": true
    }
]"
```

[#LEI-162]
