### PR TITLE
[HOLD] Feature: Update participant creation [LEI-247]

### DIFF
--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -59,7 +59,7 @@ export default Ember.Component.extend({
 
             var tag = this.get('tag');
             var batchSize = parseInt(this.get('batchSize')) || 0;
-            var accounts = this._generate(batchSize, tag);
+            var accounts = this.get('generatedParticipants');
             var store = this.get('store');
 
             var extra = {};

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 // h/t: http://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
 function makeId(len) {
     var text = '';
-    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var possible = '0123456789';
 
     for (var i = 0; i < len; i++) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
@@ -32,7 +32,14 @@ export default Ember.Component.extend({
     _generate(batchSize, tag) {
         var ret = [];
         for (let i = 0; i < batchSize; i++) {
-            ret.push(`${makeId(5)}${tag ? `-${tag}` : ''}`);
+            var generate = true;
+            while (generate) {
+                var id = `${makeId(5)}${tag ? `-${tag}` : ''}`;
+                if (!ret.contains(id) || !this.get('store').peekRecord('account', id)) {
+                    ret.push(id);
+                    generate = false;
+                }
+            }
         }
         return ret;
     },

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -45,7 +45,7 @@ export default Ember.Component.extend({
     },
     generatedParticipants: Ember.computed('batchSize', 'tag', function() {
         var tag = this.get('tag');
-        var batchSize = Math.min(parseInt(this.get('batchSize')) || 0, 10);
+        var batchSize = parseInt(this.get('batchSize')) || 0;
         return this._generate(batchSize, tag);
     }),
 

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -64,8 +64,6 @@ export default Ember.Component.extend({
                 this.set('createdAccounts', []);
             });
 
-            var tag = this.get('tag');
-            var batchSize = parseInt(this.get('batchSize')) || 0;
             var accounts = this.get('generatedParticipants');
             var store = this.get('store');
 

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -78,9 +78,6 @@
             <strong>
                 Preview:
             </strong>
-            <small class="text-muted">
-                showing up to the first ten
-            </small>
         </p>
         <div class="preview-table-wrapper">
             <table class="table table-string preview-table">
@@ -103,7 +100,7 @@
                     {{#each generatedParticipants as |id index|}}
                         <tr>
                             <td>
-                                {{index}}
+                                {{add index 1}}
                             </td>
                             <td>
                                 {{id}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-247
## Purpose
- Simplify ids by using numbers instead of alphanumeric ids
- Only create unique ids that do not already exist to prevent an error when attempting to create accounts 
## Summary of changes
- Make generated ids use only numbers
- Check to make sure no ids are duplicated in the same batch, and that the generated ids do not match an existing participant id
