### PR TITLE
Include default password in CSV [LEI-253]

### DIFF
--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -73,6 +73,12 @@ export default Ember.Component.extend({
             });
             if (!useAsPassword) {
                 password = makeId(10);
+                this.get('extra').pushObject({
+                    key: 'password',
+                    value: password
+                });
+                extra['password'] = password;
+                this.set('useAsPassword', 'password');
             }
             Ember.run.later(this, () => {
                 this.set('_creatingPromise', Ember.RSVP.allSettled(

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -115,7 +115,7 @@ export default Ember.Component.extend({
             var extra = this.get('extra');
             this.set('extra', extra.filter((item) => item.key !== field));
         },
-        useAsPassword(field, checked) {
+        useFieldAsPassword(field, checked) {
             if (checked) {
                 this.set('useAsPassword', field);
             } else {

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -19,6 +19,7 @@ export default Ember.Component.extend({
     extra: null,
     nextExtra: '',
     useAsPassword: null,
+    invalidPassword: false,
 
     creating: false,
     createdAccounts: [],
@@ -68,9 +69,16 @@ export default Ember.Component.extend({
             this.get('extra').forEach(item => {
                 if (item.key === useAsPassword) {
                     password = Ember.get(item, 'value');
+                    if (!password || password === '') {
+                        this.set('invalidPassword', true);
+                    }
                 }
                 extra[item.key] = item.value;
             });
+            if (this.get('invalidPassword')) {
+                this.set('creating', false);
+                return;
+            }
             if (!useAsPassword) {
                 password = makeId(10);
                 this.get('extra').pushObject({
@@ -127,6 +135,9 @@ export default Ember.Component.extend({
                 type: 'text/plain;charset=utf-8'
             });
             window.saveAs(blob, 'participants.csv');
+        },
+        toggleInvalidPassword: function() {
+            this.toggleProperty('invalidPassword');
         }
     }
 });

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -107,6 +107,10 @@ export default Ember.Component.extend({
                     Ember.run.later(this, () => {
                         this.set('creating', false);
                         this.send('downloadCSV');
+                        if (this.get('useAsPassword', 'password')) {
+                            this.send('removeExtraField', 'password');
+                            this.set('useAsPassword', null);
+                        }
                     }, 100);
                 }));
             }, 50);

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -120,3 +120,14 @@
         </div>
     </div>
 </div>
+
+{{#if invalidPassword}}
+  {{#bs-modal header=false body=false footer=false closedAction=(action 'toggleInvalidPassword')}}
+    {{#bs-modal-header closeButton=true}}
+      <h4>Password Required</h4>
+    {{/bs-modal-header}}
+    {{#bs-modal-body}}
+      Please enter a value to be used as the password.
+    {{/bs-modal-body}}
+  {{/bs-modal}}
+{{/if}}

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -45,7 +45,7 @@
                                     <label class="text-muted">
                                         Use as password?
                                     </label>
-                                    <input name="useAsPassword" onchange={{action (action 'useAsPassword' item.key) value="target.checked"}} type="radio" />
+                                    <input name="useAsPassword" checked={{if useAsPassword true}} onchange={{action (action 'useAsPassword' item.key) value="target.checked"}} type="radio" />
                                 </div>
                                 <div class="col-md-1">
                                     <button class="btn btn-sm btn-warning" {{action 'removeExtraField' item.key}}>X</button>

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -45,7 +45,7 @@
                                     <label class="text-muted">
                                         Use as password?
                                     </label>
-                                    <input name="useAsPassword" checked={{if useAsPassword true}} onchange={{action (action 'useAsPassword' item.key) value="target.checked"}} type="radio" />
+                                    <input name="useAsPassword" checked={{if useAsPassword true}} onchange={{action (action 'useAsPassword' item.key) value="target.checked"}} type="checkbox" />
                                 </div>
                                 <div class="col-md-1">
                                     <button class="btn btn-sm btn-warning" {{action 'removeExtraField' item.key}}>X</button>

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -45,7 +45,7 @@
                                     <label class="text-muted">
                                         Use as password?
                                     </label>
-                                    <input name="useAsPassword" checked={{if useAsPassword true}} onchange={{action (action 'useAsPassword' item.key) value="target.checked"}} type="checkbox" />
+                                    <input name="useAsPassword" checked={{if useAsPassword true}} onchange={{action (action 'useFieldAsPassword' item.key) value="target.checked"}} type="checkbox" />
                                 </div>
                                 <div class="col-md-1">
                                     <button class="btn btn-sm btn-warning" {{action 'removeExtraField' item.key}}>X</button>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-253
## Purpose

When creating accounts without an additional field used as the password, include the automatically generated password in the CSV file of participant accounts.
## Summary of changes

Add `password` as a field in `extra` and set `useAsPassword` to `password`
## Testing notes

To test, create an account without adding any additional fields and check that there is a "password" column in the resulting CSV with account information
