### PR TITLE
Add Sentry capability to experimenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ and push the changes like usual.
 To login via OSF:
 * create .env file in top directory
 * in .env file include:
-  * OSF_CLIENT_ID="\<client ID for staging account\>"
-  * OSF_SCOPE="osf.users.all_read"
-  * OSF_URL="https://staging-accounts.osf.io"
+```bash
+OSF_CLIENT_ID="\<client ID for staging account\>"
+OSF_SCOPE="osf.users.all_read"
+OSF_URL="https://staging-accounts.osf.io"
+SENTRY_DSN=""
+```
 
 First:
 * make sure jamdb is running, see: https://github.com/CenterForOpenScience/jamdb

--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-sentry/services/raven';

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "fontawesome": "~4.5.0",
     "ace-builds": "1.1.7",
     "swfobject": "*",
-    "es5-shim": "^4.5.8"
+    "es5-shim": "^4.5.8",
+    "raven-js": "~3.3"
   },
   "resolutions": {
     "moment": "2.9.0"

--- a/config/environment.js
+++ b/config/environment.js
@@ -22,6 +22,12 @@ module.exports = function(environment) {
         'ember-simple-auth': {
             authenticationRoute: 'login'
         },
+
+        sentry: {
+            dsn: process.env.SENTRY_DSN || '',
+            cdn: 'https://cdn.ravenjs.com/3.5.1/ember/raven.min.js'
+        },
+
         APP: {}
     };
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-cli-moment-shim": "1.3.0",
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-release": "0.2.8",
+    "ember-cli-sentry": "2.4.2",
     "ember-cli-uglify": "^1.2.0",
     "ember-cp-validations": "2.9.2",
     "ember-data": "^2.3.0",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-285
## Purpose

Add very basic sentry error logging to experimenter app.
## Summary of changes
- Install sentry into app
## Deployment notes

Will require setting `SENTRY_DSN` in the `.env` file as appropriate for the given deployment scenario.

We will revisit this PR once the sentry projects have been created.
