### PR TITLE
Feature: Add study id field to participant creation form [LEI-310]

### DIFF
--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -19,6 +19,7 @@ export default Ember.Component.extend({
     studyId: null,
     extra: null,
     nextExtra: '',
+    invalidStudyId: false,
 
     creating: false,
     createdAccounts: [],
@@ -63,7 +64,13 @@ export default Ember.Component.extend({
             var store = this.get('store');
 
             var extra = {};
-            extra['studyId'] = this.get('studyId');
+            var studyId = this.get('studyId');
+            if (!studyId || !studyId.trim()) {
+                this.set('invalidStudyId', true);
+                this.set('creating', false);
+                return;
+            }
+            extra['studyId'] = studyId;
             this.get('extra').forEach(item => {
                 extra[item.key] = item.value;
             });
@@ -73,7 +80,7 @@ export default Ember.Component.extend({
                     accounts.map((aId) => {
                         var attrs = {
                             id: aId,
-                            password: this.get('studyId'),
+                            password: studyId,
                             extra: extra
                         };
                         var acc = store.createRecord('account', attrs);
@@ -108,6 +115,9 @@ export default Ember.Component.extend({
                 type: 'text/plain;charset=utf-8'
             });
             window.saveAs(blob, 'participants.csv');
+        },
+        toggleInvalidStudyId: function() {
+            this.toggleProperty('invalidStudyId');
         }
     }
 });

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -101,6 +101,10 @@ export default Ember.Component.extend({
         addExtraField() {
             var next = this.get('nextExtra');
             var fieldExists = false;
+            // Do not allow users to add duplicate studyId field
+            if (next === 'studyId') {
+                fieldExists = true;
+            }
             for (var item of this.get('extra')) {
                 if (item.key === next) {
                     fieldExists = true;

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
     },
     exampleId: Ember.computed('tag', function() {
         var tag = this.get('tag');
-        return `12345${tag ? `-${tag}` : ''}`
+        return `12345${tag ? `-${tag}` : ''}`;
     }),
 
     createdAccountsCSV: Ember.computed('createdAccounts', function() {

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -20,6 +20,7 @@ export default Ember.Component.extend({
     extra: null,
     nextExtra: '',
     invalidStudyId: false,
+    invalidFieldName: false,
 
     creating: false,
     createdAccounts: [],
@@ -100,10 +101,21 @@ export default Ember.Component.extend({
         },
         addExtraField() {
             var next = this.get('nextExtra');
-            this.get('extra').pushObject({
-                key: next,
-                value: null
-            });
+            var fieldExists = false;
+            for (var item of this.get('extra')) {
+                if (item.key === next) {
+                    fieldExists = true;
+                    break;
+                }
+            }
+            if (fieldExists) {
+                this.set('invalidFieldName', true);
+            } else {
+                this.get('extra').pushObject({
+                    key: next,
+                    value: null
+                });
+            }
             this.set('nextExtra', null);
         },
         removeExtraField(field) {
@@ -118,6 +130,9 @@ export default Ember.Component.extend({
         },
         toggleInvalidStudyId: function() {
             this.toggleProperty('invalidStudyId');
+        },
+        toggleInvalidFieldName: function() {
+            this.toggleProperty('invalidFieldName');
         }
     }
 });

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -38,10 +38,9 @@ export default Ember.Component.extend({
         }
         return ret;
     },
-    generatedParticipants: Ember.computed('batchSize', 'tag', function() {
+    exampleId: Ember.computed('tag', function() {
         var tag = this.get('tag');
-        var batchSize = Math.min(parseInt(this.get('batchSize')) || 0, 10);
-        return this._generate(batchSize, tag);
+        return `12345${tag ? `-${tag}` : ''}`
     }),
 
     createdAccountsCSV: Ember.computed('createdAccounts', function() {

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -52,6 +52,13 @@ export default Ember.Component.extend({
     }),
     actions: {
         createParticipants() {
+            var studyId = this.get('studyId');
+            if (!studyId || !studyId.trim()) {
+                this.set('invalidStudyId', true);
+                this.set('creating', false);
+                return;
+            }
+
             Ember.run(() => {
                 console.log('creating...');
                 this.set('creating', true);
@@ -64,12 +71,6 @@ export default Ember.Component.extend({
             var store = this.get('store');
 
             var extra = {};
-            var studyId = this.get('studyId');
-            if (!studyId || !studyId.trim()) {
-                this.set('invalidStudyId', true);
-                this.set('creating', false);
-                return;
-            }
             extra['studyId'] = studyId;
             this.get('extra').forEach(item => {
                 extra[item.key] = item.value;

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -44,7 +44,7 @@
                                     <label>
                                         {{item.key}}:
                                     </label>
-                                    {{input value=item.value placehodler="value"}}
+                                    {{input class="form-control" value=item.value placehodler="value"}}
                                 </div>
                                 <div class="col-md-1">
                                     <button class="btn btn-sm btn-danger" {{action 'removeExtraField' item.key}}>X</button>
@@ -55,7 +55,7 @@
                 <div class="form-inline">
                     <div class="form-group">
                         <label> Add a field: </label>
-                        {{input value=nextExtra}}
+                        {{input class="form-control" value=nextExtra}}
                     </div>
                     <button disabled={{if (not nextExtra) true false}} class="btn btn-sm btn-success" {{action 'addExtraField'}}>Add</button>
                 </div>
@@ -124,5 +124,11 @@
 {{#if invalidStudyId}}
   {{#bs-modal title="Study ID Required" closedAction=(action 'toggleInvalidStudyId')}}
     {{#bs-modal-body}}Please enter a Study ID for this batch of participants.{{/bs-modal-body}}
+  {{/bs-modal}}
+{{/if}}
+
+{{#if invalidFieldName}}
+  {{#bs-modal title="Invalid Field Name" closedAction=(action 'toggleInvalidFieldName')}}
+    {{#bs-modal-body}}A field with this name already exists.{{/bs-modal-body}}
   {{/bs-modal}}
 {{/if}}

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -70,19 +70,13 @@
     <div class="col-md-4">
         <p>
             <strong>
-                Preview:
+                Example:
             </strong>
-            <small class="text-muted">
-                showing up to the first ten
-            </small>
         </p>
-        <div class="preview-table-wrapper">
+        <div>
             <table class="table table-string preview-table">
                 <thead>
                     <tr>
-                        <td>
-                            #
-                        </td>
                         <td>
                             Participant ID
                         </td>
@@ -97,24 +91,19 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {{#each generatedParticipants as |id index|}}
-                        <tr>
+                    <tr>
+                        <td>
+                            {{exampleId}}
+                        </td>
+                        <td>
+                            {{studyId}}
+                        </td>
+                        {{#each extra as |item|}}
                             <td>
-                                {{index}}
+                                {{item.value}}
                             </td>
-                            <td>
-                                {{id}}
-                            </td>
-                            <td>
-                                {{studyId}}
-                            </td>
-                            {{#each extra as |item|}}
-                                <td>
-                                    {{item.value}}
-                                </td>
-                            {{/each}}
-                        </tr>
-                    {{/each}}
+                        {{/each}}
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -24,6 +24,12 @@
                 </small>
                 {{input value=tag type="text" class="form-control"}}
             </div>
+            <div class="form-group">
+                <label>
+                    Study Id:
+                </label>
+                {{input value=studyId type="text" class="form-control"}}
+            </div>
             <div class="form-group offset-2">
                 <label>
                     Additional fields:
@@ -31,39 +37,27 @@
                 <small class="text-muted">
                     extra information for this batch of participants
                 </small>
-                <div class="form-inline">
                     {{#each extra as |item|}}
                         <div class="form-group">
                             <div class="row">
-                                <div class="col-md-5">
+                                <div class="col-md-11">
                                     <label>
                                         {{item.key}}:
                                     </label>
                                     {{input value=item.value placehodler="value"}}
                                 </div>
-                                <div class="col-md-6">
-                                    <label class="text-muted">
-                                        Use as password?
-                                    </label>
-                                    <input name="useAsPassword" onchange={{action (action 'useAsPassword' item.key) value="target.checked"}} type="radio" />
-                                </div>
                                 <div class="col-md-1">
-                                    <button class="btn btn-sm btn-warning" {{action 'removeExtraField' item.key}}>X</button>
+                                    <button class="btn btn-sm btn-danger" {{action 'removeExtraField' item.key}}>X</button>
                                 </div>
                             </div>
                         </div>
-                    {{else}}
-                        <div class="form-group">
-                            None
-                        </div>
                     {{/each}}
-                </div>
                 <div class="form-inline">
                     <div class="form-group">
                         <label> Add a field: </label>
                         {{input value=nextExtra}}
                     </div>
-                    <button disabled={{if (not nextExtra) true false}} class="btn btn-sm btn-default" {{action 'addExtraField'}}>Add</button>
+                    <button disabled={{if (not nextExtra) true false}} class="btn btn-sm btn-success" {{action 'addExtraField'}}>Add</button>
                 </div>
             </div>
             <div class="form-group">
@@ -92,6 +86,9 @@
                         <td>
                             Participant id
                         </td>
+                        <td>
+                            Study id
+                        </td>
                         {{#each extra as |item|}}
                             <td>
                                 {{item.key}}
@@ -107,6 +104,9 @@
                             </td>
                             <td>
                                 {{id}}
+                            </td>
+                            <td>
+                                {{studyId}}
                             </td>
                             {{#each extra as |item|}}
                                 <td>

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -26,7 +26,7 @@
             </div>
             <div class="form-group">
                 <label>
-                    Study Id:
+                    Study ID:
                 </label>
                 {{input value=studyId type="text" class="form-control"}}
             </div>
@@ -84,10 +84,10 @@
                             #
                         </td>
                         <td>
-                            Participant id
+                            Participant ID
                         </td>
                         <td>
-                            Study id
+                            Study ID
                         </td>
                         {{#each extra as |item|}}
                             <td>
@@ -120,3 +120,9 @@
         </div>
     </div>
 </div>
+
+{{#if invalidStudyId}}
+  {{#bs-modal title="Study ID Required" closedAction=(action 'toggleInvalidStudyId')}}
+    {{#bs-modal-body}}Please enter a Study ID for this batch of participants.{{/bs-modal-body}}
+  {{/bs-modal}}
+{{/if}}

--- a/app/styles/components/participant-creator.scss
+++ b/app/styles/components/participant-creator.scss
@@ -1,7 +1,3 @@
-.participant-creator .preview-table-wrapper {
-    height: 300px !important;
-    overflow-y: scroll;
-}
 .participant-creator .block-ui {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-310

## Purpose
- Update participant creation interface UI 

## Summary of changes
- Add Study ID field to participant creation interface form
- Show error message if user tries to create accounts without entering a Study ID
- Show error message if user tries to add two "Additional Fields" with the same name
- Only show one example participant, instead of 10  

![screen shot 2016-11-08 at 3 38 33 pm](https://cloud.githubusercontent.com/assets/6414394/20150934/2f03d056-a686-11e6-877a-c3c6ff3a35ce.png)


## Testing notes
- Try creating an account without a study id (should see error modal appear)
- Try adding two "Additional Fields" with the same name (should see error modal appear)
- Change the batch size to a number other than 1 and check that there is still only one example
