### PR TITLE
[rfr] Add support for bulk participant creation

### DIFF
--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { validator, buildValidations } from 'ember-cp-validations';
 
 // h/t: http://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
 function makeId(len) {
@@ -11,7 +12,16 @@ function makeId(len) {
     return text;
 }
 
-export default Ember.Component.extend({
+const Validations = buildValidations({
+    batchSize: validator('number', {
+        gt: 0,
+        lte: 100,
+        integer: true,
+        allowString: true
+    })
+});
+
+export default Ember.Component.extend(Validations, {
     store: Ember.inject.service(),
 
     batchSize: 1,

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -23,6 +23,10 @@ const Validations = buildValidations({
         lte: 100,
         integer: true,
         allowString: true
+    }),
+    studyId: validator('presence', {
+        presence: true,
+        ignoreBlank: true
     })
 });
 
@@ -44,11 +48,11 @@ export default Ember.Component.extend(Validations, {
     studyId: null,
     extra: null,
     nextExtra: '',
-    invalidStudyId: false,
     invalidFieldName: false,
 
     creating: false,
     createdAccounts: null,
+    showErrors: false,
 
     init() {
         this._super(...arguments);
@@ -102,12 +106,13 @@ export default Ember.Component.extend(Validations, {
     }).volatile(),
     actions: {
         createParticipants(batchSize) {
-            var studyId = this.get('studyId');
-            if (!studyId || !studyId.trim()) {
-                this.set('invalidStudyId', true);
-                this.set('creating', false);
+            // Only show messages after first attempt to submit form
+            this.set('showErrors', true);
+            if (!this.get('validations.isValid')) {
                 return;
             }
+
+            var studyId = this.get('studyId');
 
             var tag = this.get('tag');
             batchSize = parseInt(batchSize) || 0;
@@ -177,9 +182,6 @@ export default Ember.Component.extend(Validations, {
                 type: 'text/plain;charset=utf-8'
             });
             window.saveAs(blob, 'participants.csv');
-        },
-        toggleInvalidStudyId: function() {
-            this.toggleProperty('invalidStudyId');
         },
         toggleInvalidFieldName: function() {
             this.toggleProperty('invalidFieldName');

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -47,7 +47,7 @@
                                     <label>
                                         {{item.key}}:
                                     </label>
-                                    {{input class="form-control" value=item.value placehodler="value"}}
+                                    {{input class="form-control" value=item.value}}
                                 </div>
                                 <div class="col-md-1">
                                     <button class="btn btn-sm btn-danger" {{action 'removeExtraField' item.key}}>X</button>

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -70,7 +70,7 @@
                 </div>
             </div>
             <div class="form-group">
-                <button disabled={{validations.isInvalid}} class="btn btn-primary" {{action 'createParticipants'}}>
+                <button disabled={{validations.isInvalid}} class="btn btn-primary" {{action 'createParticipants' batchSize}}>
                     Create accounts
                 </button>
             </div>

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -1,7 +1,7 @@
 <div class="row participant-creator">
     <div class="{{if creating 'block-ui' 'block-ui-hidden'}}">
         <span class="block-ui-message">
-            Created {{createdAccounts.length}} out of {{batchSize}}
+            Creating new records; please wait
         </span>
     </div>
     <div class="col-md-6">

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -6,14 +6,17 @@
     </div>
     <div class="col-md-6">
         <div class="form">
-            <div class="form-group">
+            <div class="form-group {{if (v-get this 'batchSize' 'isInvalid') 'has-error' }}">
                 <label>
                     Batch size:
                     <small class="text-muted">
                         how many participants to create
                     </small>
                 </label>
-                {{input value=batchSize type="number" class="form-control"}}
+                {{input value=batchSize type="number" min=0 max=100 class="form-control"}}
+                <span class="text-danger">
+                    {{v-get this 'batchSize' 'message'}}
+                </span>
             </div>
             <div class="form-group">
                 <label>
@@ -67,7 +70,7 @@
                 </div>
             </div>
             <div class="form-group">
-                <button disabled={{if (not batchSize) true false}} class="btn btn-primary" {{action 'createParticipants'}}>
+                <button disabled={{validations.isInvalid}} class="btn btn-primary" {{action 'createParticipants'}}>
                     Create accounts
                 </button>
             </div>

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -6,7 +6,7 @@
     </div>
     <div class="col-md-6">
         <div class="form">
-            <div class="form-group {{if (v-get this 'batchSize' 'isInvalid') 'has-error' }}">
+            <div class="form-group {{if (v-get this 'batchSize' 'isInvalid') 'has-error'}}">
                 <label>
                     Batch size:
                     <small class="text-muted">
@@ -14,7 +14,7 @@
                     </small>
                 </label>
                 {{input value=batchSize type="number" min=0 max=100 class="form-control"}}
-                <span class="text-danger">
+                <span class="text-danger {{unless showErrors 'hidden'}}">
                     {{v-get this 'batchSize' 'message'}}
                 </span>
             </div>
@@ -27,11 +27,14 @@
                 </small>
                 {{input value=tag type="text" class="form-control"}}
             </div>
-            <div class="form-group">
+            <div class="form-group {{if (v-get this 'batchSize' 'isInvalid') 'has-error'}}">
                 <label>
                     Study ID:
                 </label>
                 {{input value=studyId type="text" class="form-control"}}
+                <span class="text-danger {{unless showErrors 'hidden'}}">
+                    {{v-get this 'studyId' 'message'}}
+                </span>
             </div>
             <div class="form-group offset-2">
                 <label>
@@ -60,11 +63,11 @@
                         <label> Add a field: </label>
                         {{input class="form-control" value=nextExtra}}
                     </div>
-                    <button disabled={{if (not nextExtra) true false}} class="btn btn-sm btn-success" {{action 'addExtraField'}}>Add</button>
+                    <button disabled={{if (not nextExtra) true false}} class="btn btn-sm btn-primary" {{action 'addExtraField'}}>Add</button>
                 </div>
             </div>
             <div class="form-group">
-                <button disabled={{validations.isInvalid}} class="btn btn-primary" {{action 'createParticipants' batchSize}}>
+                <button class="btn btn-success" {{action 'createParticipants' batchSize}}>
                     Create accounts
                 </button>
             </div>
@@ -112,12 +115,6 @@
         </div>
     </div>
 </div>
-
-{{#if invalidStudyId}}
-  {{#bs-modal title="Study ID Required" closedAction=(action 'toggleInvalidStudyId')}}
-    {{#bs-modal-body}}Please enter a Study ID for this batch of participants.{{/bs-modal-body}}
-  {{/bs-modal}}
-{{/if}}
 
 {{#if invalidFieldName}}
   {{#bs-modal title="Invalid Field Name" closedAction=(action 'toggleInvalidFieldName')}}

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -6,7 +6,7 @@
     </div>
     <div class="col-md-6">
         <div class="form">
-            <div class="form-group {{if (v-get this 'batchSize' 'isInvalid') 'has-error'}}">
+            <div class="form-group {{if (and showErrors (v-get this 'batchSize' 'isInvalid')) 'has-error'}}">
                 <label>
                     Batch size:
                     <small class="text-muted">
@@ -27,7 +27,7 @@
                 </small>
                 {{input value=tag type="text" class="form-control"}}
             </div>
-            <div class="form-group {{if (v-get this 'batchSize' 'isInvalid') 'has-error'}}">
+            <div class="form-group {{if (and showErrors (v-get this 'studyId' 'isInvalid')) 'has-error'}}">
                 <label>
                     Study ID:
                 </label>

--- a/app/routes/participants/index.js
+++ b/app/routes/participants/index.js
@@ -1,8 +1,4 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
-    model() {
-        return this.store.findAll('account');
-  	}
-});
+export default Ember.Route.extend(AuthenticatedRouteMixin, {});


### PR DESCRIPTION
Refs:
 https://openscience.atlassian.net/browse/LEI-305
(and maybe) https://openscience.atlassian.net/browse/LEI-312

⚠️ Depends on, and must be merged after updating submodule commit to reflect:
 https://github.com/CenterForOpenScience/exp-addons/pull/198

## Purpose
Add support for bulk participant creation. Limit to 100 records per attempt.

## Summary of changes
- Add bulk support for account creation: send 100 records in 1 request instead of 100
- Rely on JamDB bulk error reporting failure mechanism- instead of preemptively checking that a record exists already and guaranteeing 100 creations, let some fail and report how many succeeded. (may get a 200 status even if individual creation operations fail)

## Testing notes
- Create 1 record, check CSV
- Create 1 record with a specified field containing a password, and make sure extra fields are saved to CSV file
- Enter invalid batch size or study ID. Validation error text should not show initially, but should always show after the first time you click "create". Errors should display inline under the affected field.
- Batch size should be limited to 100, and validation should show errors when appropriate. Try typing in a batch size of 0, 1, 1.5, 100, and 101.
- Batch-create 2 records. Without reloading the page, create another batch of 2 participants. Each CSV file should cover only the entries created in that batch.
- Try to create 2 records, but edit the code for `createParticipants` to add a third record ID that already exists. The response payload should report 2 successful creations and one null placeholder in the data section (for the 3 records sent to the server), with 2 null placeholders and one "Document already exists" value in "errors" . 

## Known issues
- The UI appears to hang when creating a lot of records; this is not because of network requests. It seems that serialization is the slow step (because of bcrypt being done on the front end, which unfortunately is a requirement for now). Effectively, we made this operation take a long time for the user, *by design*.
  - We should try to make the UI more responsive in the future.