### PR TITLE
[rfr] Results page should handle pagination and fetching of all data

### DIFF
--- a/app/components/participant-data.js
+++ b/app/components/participant-data.js
@@ -6,19 +6,13 @@ export default Ember.Component.extend({
     sortBy: 'profileId',
     reverse: false,
     mappingFunction: null,
-    sortedSessions: Ember.computed('sortBy', 'reverse', {
-        get() {
-            var reverse = this.get('reverse');
-            var sortBy = this.get('sortBy');
-            if (reverse) {
-                return this.get('sessions').sortBy(sortBy).reverse();
-            }
-            return this.get('sessions').sortBy(sortBy);
-        },
-        set(_, value) {
-            this.set('sortedSessions', value);
-            return value;
+    sortedSessions: Ember.computed('sortBy', 'reverse', 'sessions', function() {
+        var reverse = this.get('reverse');
+        var sortBy = this.get('sortBy');
+        if (reverse) {
+            return this.get('sessions').sortBy(sortBy).reverse();
         }
+        return this.get('sessions').sortBy(sortBy);
     }),
     actions: {
         updateData: function(session) {

--- a/app/components/participant-data.js
+++ b/app/components/participant-data.js
@@ -6,14 +6,7 @@ export default Ember.Component.extend({
     sortBy: 'profileId',
     reverse: false,
     mappingFunction: null,
-    sortedSessions: Ember.computed('sortBy', 'reverse', 'sessions', function() {
-        var reverse = this.get('reverse');
-        var sortBy = this.get('sortBy');
-        if (reverse) {
-            return this.get('sessions').sortBy(sortBy).reverse();
-        }
-        return this.get('sessions').sortBy(sortBy);
-    }),
+
     actions: {
         updateData: function(session) {
             this.set('participantSession', [session]);
@@ -28,6 +21,9 @@ export default Ember.Component.extend({
                 this.set('reverse', false);
             }
             this.set('sortBy', sortBy);
+
+            const rawField = sortBy === 'modifiedOn' ? 'modified_on' : sortBy;
+            this.sendAction('changeSort', rawField, this.get('reverse'));
         }
     }
 });

--- a/app/controllers/experiments/info/results.js
+++ b/app/controllers/experiments/info/results.js
@@ -2,9 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
     breadCrumb: 'Responses',
-    experiment: null,
-    sessions: null,
-    sanitizeProfileId: function(session) {
+    sanitizeProfileId (session) {
         session.profileId = session.profileId.split('.').slice(-1)[0];
         return session;
     }

--- a/app/controllers/experiments/info/results/index.js
+++ b/app/controllers/experiments/info/results/index.js
@@ -3,4 +3,8 @@ import PaginatedControllerMixin from '../../../../mixins/paginated-controller';
 
 export default Ember.Controller.extend(PaginatedControllerMixin, {
     page_size: 20,
+
+    totalPages: Ember.computed('model', function() {
+        return Math.ceil(this.get('model.meta.total') / this.get('page_size'));
+    })
 });

--- a/app/controllers/experiments/info/results/index.js
+++ b/app/controllers/experiments/info/results/index.js
@@ -4,7 +4,23 @@ import PaginatedControllerMixin from '../../../../mixins/paginated-controller';
 export default Ember.Controller.extend(PaginatedControllerMixin, {
     page_size: 10,
 
+    queryParams: ['sort'],
+    sort: '',
+
     totalPages: Ember.computed('model', function() {
         return Math.ceil(this.get('model.meta.total') / this.get('page_size'));
-    })
+    }),
+
+    actions: {
+        /**
+         * Change the sort direction (and adapt field names from ember-data to raw queries)
+         *
+         * @param {String} field name
+         * @param reverse
+         */
+        changeSort(field, reverse) {
+            const direction = reverse ? '-' : '+';
+            this.set('sort', direction + field);
+        }
+    }
 });

--- a/app/controllers/experiments/info/results/index.js
+++ b/app/controllers/experiments/info/results/index.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import PaginatedControllerMixin from '../../../../mixins/paginated-controller';
+
+export default Ember.Controller.extend(PaginatedControllerMixin, {
+    page_size: 20,
+});

--- a/app/controllers/experiments/info/results/index.js
+++ b/app/controllers/experiments/info/results/index.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import PaginatedControllerMixin from '../../../../mixins/paginated-controller';
 
 export default Ember.Controller.extend(PaginatedControllerMixin, {
-    page_size: 20,
+    page_size: 10,
 
     totalPages: Ember.computed('model', function() {
         return Math.ceil(this.get('model.meta.total') / this.get('page_size'));

--- a/app/mixins/paginated-controller.js
+++ b/app/mixins/paginated-controller.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+
+/**
+ * @module experimenter
+ * @submodule mixins
+ */
+
+/**
+ * Controller mixin to support fetching paginated results. (borrowed from ember-osf)
+ *
+ * Because this uses query parameters, it should be used in tandem with PaginatedRouteMixin
+ *
+ * @class PaginatedControllerMixin
+ * @extends Ember.Mixin
+ */
+export default Ember.Mixin.create({
+    queryParams: ['page', 'page_size'],
+    page: 1,  // Current page
+    page_size: null,  // Number of results per page. Param may be omitted.
+
+    totalResults: Ember.computed('model', function() {
+        return this.get('model.meta.pagination.total');
+    }),
+    totalPages: Ember.computed('model', 'totalResults', function() {
+        let results = this.get('totalResults');
+        let pageSize = this.get('model.meta.pagination.per_page');
+        return Math.ceil(results / pageSize);
+    }),
+
+    actions: {
+        previous() {
+            this.decrementProperty('page', 1);
+        },
+        next() {
+            this.incrementProperty('page', 1);
+        },
+        goToPage(pageNumber) {
+            this.set('page', pageNumber);
+        }
+    }
+});

--- a/app/mixins/paginated-route.js
+++ b/app/mixins/paginated-route.js
@@ -1,0 +1,78 @@
+import Ember from 'ember';
+
+/**
+ * @module experimenter
+ * @submodule mixins
+ */
+
+/**
+ * Route mixin to support fetching paginated results. (borrowed from ember-osf)
+ *
+ * Because this uses query parameters, it should be used in tandem with PaginatedControllerMixin
+ *
+ * @class PaginatedRouteMixin
+ * @extends Ember.Mixin
+ */
+export default Ember.Mixin.create({
+    // When page numbers are updated, fetch the new results from the server
+    queryParams: {
+        page: {
+            refreshModel: true
+        },
+        page_size: {
+            refreshModel: true
+        }
+    },
+
+    /**
+     * Allow configuration of the backend URL parameter used for page #
+     * @property pageParam
+     * @type String
+     * @default "page"
+     */
+    pageParam: 'page',
+
+    /**
+     * Allow configuration of the backend URL parameter for number of results per page
+     * @property perPageParam
+     * @type String
+     * @default "page[size]"
+     */
+    perPageParam: 'page[size]',
+
+    /**
+     * Fetch a route-specified page of results from an external API
+     *
+     * To use this argument, pass the params from the model hook as the first argument.
+     * ```javascript
+     * model(routeParams) {
+     *   return this.queryForPage('user', routeParams);
+     * }
+     * ```
+     *
+     * @method queryForPage
+     * @param modelName The name of the model to query in the store
+     * @param routeParams Parameters dictionary available to the model hook; must be passed in manually
+     * @param userParams Additional user-specified query parameters to further customize the query
+     * @return {Promise}
+     */
+    queryForPage(modelName, routeParams, userParams) {
+        userParams = userParams || {};
+        let params = Object.assign({}, userParams || {}, routeParams);
+
+        // TODO: Are routeParams necessary?
+        // Rename the ember-route URL params to what the backend API expects, and remove the old param if necessary
+        const page = params.page;
+        delete params.page;
+
+        const pageSize = params.page_size;
+        delete params.page_size;
+        if (page) {
+            params[this.get('pageParam')] = page;
+        }
+        if (pageSize) {
+            params[this.get('perPageParam')] = pageSize;
+        }
+        return this.store.query(modelName, params);
+    }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -2,45 +2,39 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType,
-  rootURL: config.rootURL
+    location: config.locationType,
+    rootURL: config.rootURL
 });
 
-Router.map(function() {
+Router.map(function () {
     this.route('index', {
         path: '/'
     });
 
     this.route('login');
 
-    this.route('errors', function() {
+    this.route('errors', function () {
         this.route('generic');
     });
 
-    this.route('experiments', function() {
+    this.route('experiments', function () {
         this.route('list', {
             path: '/'
         });
         this.route('info', {
             path: '/:experiment_id'
-        }, function() {
+        }, function () {
             this.route('index', {
                 path: '/'
             });
-            this.route('edit', {
-                path: '/edit/'
-            });
-            this.route('results', {
-                path: '/results/'
-            });
-            this.route('preview', {
-                path: '/preview/'
-            });
+            this.route('edit');
+            this.route('results');
+            this.route('preview');
 
         });
     });
 
-    this.route('participants', function() {
+    this.route('participants', function () {
         this.route('profile', {
             path: ':profile_id/'
         });

--- a/app/router.js
+++ b/app/router.js
@@ -24,13 +24,11 @@ Router.map(function () {
         this.route('info', {
             path: '/:experiment_id'
         }, function () {
-            this.route('index', {
-                path: '/'
-            });
             this.route('edit');
-            this.route('results');
+            this.route('results', function() {
+              this.route('all');
+            });
             this.route('preview');
-
         });
     });
 

--- a/app/routes/experiments/info/results.js
+++ b/app/routes/experiments/info/results.js
@@ -2,13 +2,4 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
-    model() {
-        let experiment = this.modelFor('experiments/info');
-        return this.store.query(experiment.get('sessionCollectionId'),
-            {
-                'filter[completed]': 1,
-                'page[size]':100
-            });
-    }
-});
+export default Ember.Route.extend(AuthenticatedRouteMixin, {});

--- a/app/routes/experiments/info/results/all.js
+++ b/app/routes/experiments/info/results/all.js
@@ -12,7 +12,7 @@ export default Ember.Route.extend({
     _fetchResults(collectionName, dest, page) {
         const options = {
                 'filter[completed]': 1,
-                'page[size]': 3,
+                'page[size]': 100,
                 'page': page
         };
         return this.store.query(collectionName, options).then(res => {

--- a/app/routes/experiments/info/results/all.js
+++ b/app/routes/experiments/info/results/all.js
@@ -7,7 +7,7 @@ export default Ember.Route.extend({
         return this.store.query(experiment.get('sessionCollectionId'),
             {
                 'filter[completed]': 1,
-                'page[size]': 20
+                'page[size]': 100
             });
     },
 

--- a/app/routes/experiments/info/results/all.js
+++ b/app/routes/experiments/info/results/all.js
@@ -1,14 +1,36 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-    model() {
-        //TODO: Get every record EVER, and maybe implement a loading substate template?
-        const experiment = this.modelFor('experiments.info');
-        return this.store.query(experiment.get('sessionCollectionId'),
-            {
+    /**
+     *
+     * @param {String} collectionName Name of the collection to query
+     * @param {Array} dest An array to be used for storing the combined results of all requests
+     * @param {Number} page The current page number to fetch
+     * @returns {Promise} A (chained) promise that will resolve to dest when all records have been fetched
+     * @private
+     */
+    _fetchResults(collectionName, dest, page) {
+        const options = {
                 'filter[completed]': 1,
-                'page[size]': 100
-            });
+                'page[size]': 3,
+                'page': page
+        };
+        return this.store.query(collectionName, options).then(res => {
+            const theseResults = res.toArray();
+            dest.push(...theseResults);
+            // TODO: This is an imperfect means of identifying the last page, but JamDB doesn't tell us directly
+            if (theseResults.length !== 0 && dest.length <  res.get('meta.total')) {
+                return this._fetchResults(collectionName, dest, page + 1);
+            } else {
+                return dest;
+            }
+        });
+    },
+
+    model() {
+        const collectionName = this.modelFor('experiments.info').get('sessionCollectionId');
+        const results = Ember.A();
+        return this._fetchResults(collectionName, results, 1);
     },
 
     setupController(controller) {

--- a/app/routes/experiments/info/results/all.js
+++ b/app/routes/experiments/info/results/all.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    model() {
+        //TODO: Get every record EVER, and maybe implement a loading substate template?
+        const experiment = this.modelFor('experiments.info');
+        return this.store.query(experiment.get('sessionCollectionId'),
+            {
+                'filter[completed]': 1,
+                'page[size]': 20
+            });
+    },
+
+    setupController(controller) {
+        // Small hack to reuse code
+        const sanitizeProfileId = this.controllerFor('experiments.info.results').get('sanitizeProfileId');
+        controller.set('sanitizeProfileId', sanitizeProfileId);
+
+        return this._super(...arguments);
+    }
+});

--- a/app/routes/experiments/info/results/index.js
+++ b/app/routes/experiments/info/results/index.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    model() {
+        const experiment = this.modelFor('experiments.info');
+        return this.store.query(experiment.get('sessionCollectionId'),
+            {
+                'filter[completed]': 1,
+                'page[size]': 20
+            });
+    },
+
+    setupController(controller) {
+        // Small hack to reuse code
+        const sanitizeProfileId = this.controllerFor('experiments.info.results').get('sanitizeProfileId');
+        controller.set('sanitizeProfileId', sanitizeProfileId);
+
+        return this._super(...arguments);
+    }
+});

--- a/app/routes/experiments/info/results/index.js
+++ b/app/routes/experiments/info/results/index.js
@@ -3,6 +3,12 @@ import PaginatedRouteMixin from '../../../../mixins/paginated-route';
 
 
 export default Ember.Route.extend(PaginatedRouteMixin, {
+    queryParams: {
+        sort: {
+            refreshModel: true
+        }
+    },
+
     model(params) {
         const experiment = this.modelFor('experiments.info');
         return this.queryForPage(experiment.get('sessionCollectionId'), params, {

--- a/app/routes/experiments/info/results/index.js
+++ b/app/routes/experiments/info/results/index.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
+import PaginatedRouteMixin from '../../../../mixins/paginated-route';
 
-export default Ember.Route.extend({
-    model() {
+
+export default Ember.Route.extend(PaginatedRouteMixin, {
+    model(params) {
         const experiment = this.modelFor('experiments.info');
-        return this.store.query(experiment.get('sessionCollectionId'),
-            {
-                'filter[completed]': 1,
-                'page[size]': 20
-            });
+        return this.queryForPage(experiment.get('sessionCollectionId'), params, {
+            'filter[completed]': 1,
+        });
     },
 
     setupController(controller) {

--- a/app/templates/components/participant-data.hbs
+++ b/app/templates/components/participant-data.hbs
@@ -7,7 +7,7 @@
       </tr>
     </thead>
     <tbody>
-      {{#each sortedSessions as |session|}}
+      {{#each sessions as |session|}}
         <tr class="clickable-row" {{action 'updateData' session}}>
           <td>{{session.anonProfileId}}</td>
           <td>{{moment-format session.modifiedOn 'MM/DD/YYYY'}}</td>

--- a/app/templates/components/participant-data.hbs
+++ b/app/templates/components/participant-data.hbs
@@ -3,14 +3,14 @@
     <thead>
       <tr>
         <th>Participant ID<i class="fa fa-sort btn" {{action "updateSortBy" "profileId"}}></i></th>
-        <th>Date<i class="fa fa-sort btn" {{action "updateSortBy" "createdOn"}}></i></th>
+        <th>Date<i class="fa fa-sort btn" {{action "updateSortBy" "modifiedOn"}}></i></th>
       </tr>
     </thead>
     <tbody>
       {{#each sortedSessions as |session|}}
         <tr class="clickable-row" {{action 'updateData' session}}>
           <td>{{session.anonProfileId}}</td>
-          <td>{{moment-format session.createdOn 'MM/DD/YYYY'}}</td>
+          <td>{{moment-format session.modifiedOn 'MM/DD/YYYY'}}</td>
         </tr>
       {{/each}}
     </tbody>

--- a/app/templates/experiments/info/results.hbs
+++ b/app/templates/experiments/info/results.hbs
@@ -1,9 +1,12 @@
 <h2>Responses</h2>
-{{#bs-tab}}
-  {{#bs-tab-pane title="Participant Data"}}
-      {{participant-data sessions=model mappingFunction=sanitizeProfileId}}
-  {{/bs-tab-pane}}
-  {{#bs-tab-pane title="All Data"}}
-      {{export-tool data=model mappingFunction=sanitizeProfileId}}
-  {{/bs-tab-pane}}
-{{/bs-tab}}
+
+<ul class="nav nav-tabs">
+    {{#link-to "experiments.info.results.index" tagName="li"}}
+        <a href="#">Suggested Studies</a>
+    {{/link-to}}
+    {{#link-to "experiments.info.results.all" tagName="li"}}
+        <a href="#">Past Studies</a>
+    {{/link-to}}
+</ul>
+
+{{outlet}}

--- a/app/templates/experiments/info/results.hbs
+++ b/app/templates/experiments/info/results.hbs
@@ -2,10 +2,10 @@
 
 <ul class="nav nav-tabs">
     {{#link-to "experiments.info.results.index" tagName="li"}}
-        <a href="#">Suggested Studies</a>
+        <a href="#">Participant Data</a>
     {{/link-to}}
     {{#link-to "experiments.info.results.all" tagName="li"}}
-        <a href="#">Past Studies</a>
+        <a href="#">All Data</a>
     {{/link-to}}
 </ul>
 

--- a/app/templates/experiments/info/results/all-loading.hbs
+++ b/app/templates/experiments/info/results/all-loading.hbs
@@ -1,6 +1,8 @@
 <div class="row">
     <div class="col-xs-4 col-xs-offset-4" style="height:100%">
-        Please wait. Our team of trained rescue cats is currently fetching your data.
+        <p>
+            Please wait. Our team of trained rescue cats is currently fetching your data.
+        </p>
         <p class="text-center">
             <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>
         </p>

--- a/app/templates/experiments/info/results/all-loading.hbs
+++ b/app/templates/experiments/info/results/all-loading.hbs
@@ -1,0 +1,8 @@
+<div class="row">
+    <div class="col-xs-4 col-xs-offset-4" style="height:100%">
+        Please wait. Our team of trained rescue cats is currently fetching your data.
+        <p class="text-center">
+            <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>
+        </p>
+    </div>
+</div>

--- a/app/templates/experiments/info/results/all-loading.hbs
+++ b/app/templates/experiments/info/results/all-loading.hbs
@@ -1,5 +1,5 @@
 <div class="row">
-    <div class="col-xs-4 col-xs-offset-4" style="height:100%">
+    <div class="col-xs-4 col-xs-offset-4">
         <p>
             Please wait. Our team of trained rescue cats is currently fetching your data.
         </p>

--- a/app/templates/experiments/info/results/all.hbs
+++ b/app/templates/experiments/info/results/all.hbs
@@ -1,0 +1,1 @@
+{{export-tool data=model mappingFunction=sanitizeProfileId}}

--- a/app/templates/experiments/info/results/index.hbs
+++ b/app/templates/experiments/info/results/index.hbs
@@ -1,3 +1,3 @@
 {{participant-data sessions=model mappingFunction=sanitizeProfileId}}
 
-{{pagination-pager current=page count=10}}
+{{pagination-pager current=page count=totalPages}}

--- a/app/templates/experiments/info/results/index.hbs
+++ b/app/templates/experiments/info/results/index.hbs
@@ -1,0 +1,1 @@
+{{participant-data sessions=model mappingFunction=sanitizeProfileId}}

--- a/app/templates/experiments/info/results/index.hbs
+++ b/app/templates/experiments/info/results/index.hbs
@@ -1,1 +1,3 @@
 {{participant-data sessions=model mappingFunction=sanitizeProfileId}}
+
+{{pagination-pager current=page count=10}}

--- a/app/templates/experiments/info/results/index.hbs
+++ b/app/templates/experiments/info/results/index.hbs
@@ -1,3 +1,6 @@
+<p>
+    There are {{model.meta.total}} total completed responses. Viewing page {{page}} of {{totalPages}}
+</p>
 {{participant-data sessions=model mappingFunction=sanitizeProfileId}}
 
 {{pagination-pager current=page count=totalPages}}

--- a/app/templates/experiments/info/results/index.hbs
+++ b/app/templates/experiments/info/results/index.hbs
@@ -2,7 +2,7 @@
     There are {{model.meta.total}} total completed responses. Viewing page {{page}} of {{totalPages}}
 </p>
 <div class="row">
-    {{participant-data sessions=model mappingFunction=sanitizeProfileId}}
+    {{participant-data sessions=model mappingFunction=sanitizeProfileId changeSort='changeSort'}}
 </div>
 
 <div class="row">

--- a/app/templates/experiments/info/results/index.hbs
+++ b/app/templates/experiments/info/results/index.hbs
@@ -1,6 +1,13 @@
 <p>
     There are {{model.meta.total}} total completed responses. Viewing page {{page}} of {{totalPages}}
 </p>
-{{participant-data sessions=model mappingFunction=sanitizeProfileId}}
+<div class="row">
+    {{participant-data sessions=model mappingFunction=sanitizeProfileId}}
+</div>
 
-{{pagination-pager current=page count=totalPages}}
+<div class="row">
+    <div class="col-md-12">
+        {{pagination-pager current=page count=totalPages}}
+    </div>
+</div>
+

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "loader.js": "^4.0.1",
     "moment": "2.11.2",
     "moment-timezone": "0.5.0",
+    "pagination-pager": "2.4.2",
     "request": "^2.69.0",
     "request-promise": "^2.0.0",
     "rimraf": "^2.5.2",

--- a/tests/unit/routes/experiments/info/results/all-test.js
+++ b/tests/unit/routes/experiments/info/results/all-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:experiments/info/results/all', 'Unit | Route | experiments/info/results/all', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/routes/experiments/info/results/index-test.js
+++ b/tests/unit/routes/experiments/info/results/index-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:experiments/info/results/index', 'Unit | Route | experiments/info/results/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-291

## Purpose
The results page is currently limited to the first 100 results. It should change as follows:
1. The "see individual participant" page should use pagination (10-20 results at a time) with a pagination widget that can be used to get more data as needed.
2. The "see all data page" should fetch all results available, not just the first 100. (ISP will need more than 100 results!)

<img width="593" alt="screen shot 2016-11-11 at 3 45 32 pm" src="https://cloud.githubusercontent.com/assets/2957073/20229707/ee28aef2-a825-11e6-861a-605732f17c57.png">
<img width="1041" alt="screen shot 2016-11-11 at 3 46 14 pm" src="https://cloud.githubusercontent.com/assets/2957073/20229720/00de970a-a826-11e6-919d-6e020907a31e.png">


## Summary of changes
- [x] Reorganize `experiments/<id>/results` into two subroutes: `index` and `all`. That way, the page can load faster if you don't want all data.
- [x] Add a "slow loading" substate for the all route (to give visual feedback when something might take a while)
- [x] Implement pagination widgets and mixins
- [x] Use pagination for the `experiments.index` route (which shows individual results)
- [x] Show a count of total results on the `experiments.index` route
- [x] Implement loadAll behavior for `experiments.all` route.

## Testing notes
- Visit the results page for something with multiple results, like http://localhost:4201/experiments/57586a553de08a005bb8fb7f/results/all
- Force those results to be split across multiple pages by changing `results.index` variable `page_size` to a smaller number. Verify that user can navigate between several pages of results.

- Because there may be a lot of records, the `/all` route has a special new `loading` substate, which will render while data is being fetched. You can simulate slower loading by either
  - Reducing the page size in the model hook for the `all` route (so more network requests occur), or
  - Generating a guaranteed time delay by changing the model hook to the following:
```
        // Simulate a slow model for loading purposes
        return new Ember.RSVP.Promise((resolve) => {
            Ember.run.later(resolve, 5000);
        });
```

