### PR TITLE
Feature/lei247 numeric participant ids

### DIFF
--- a/.env-travis
+++ b/.env-travis
@@ -1,5 +1,5 @@
 OSF_CLIENT_ID=<CLIENT_ID>
-OSF_SCOPE=osf.users.all_read
+OSF_SCOPE=osf.users.profile_read
 OSF_URL=https://staging.osf.io
 OSF_AUTH_URL=https://staging-accounts.osf.io
 JAMDB_NAMESPACE=experimenter

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ To login via OSF:
 * in .env file include:
 ```bash
 OSF_CLIENT_ID="\<client ID for staging account\>"
-OSF_SCOPE="osf.users.all_read"
+OSF_SCOPE="osf.users.profile_read"
 OSF_URL="https://staging-accounts.osf.io"
 SENTRY_DSN=""
+WOWZA_PHP='{}'
+WOWZA_ASP='{}'
 ```
 
 First:

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -8,10 +8,10 @@ import { validator, buildValidations } from 'ember-cp-validations';
 
 // h/t: http://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
 function makeId(len) {
-    var text = '';
-    var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let text = '';
+    const possible = '0123456789';
 
-    for (var i = 0; i < len; i++) {
+    for (let i = 0; i < len; i++) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
     }
     return text;
@@ -69,7 +69,7 @@ export default Ember.Component.extend(Validations, {
     _generate(batchSize, tag) {
         var ret = [];
         for (let i = 0; i < batchSize; i++) {
-            ret.push(`${makeId(5)}${tag ? `-${tag}` : ''}`);
+            ret.push(`${makeId(10)}${tag ? `-${tag}` : ''}`);
         }
         return ret;
     },


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-247

## Purpose
Make user IDs numeric instead of alphanumeric, in order to help users of foreign keyboards.

## Summary of changes
- User IDs are 10 characters long instead of 5
- User IDs contain only digits

Other:
- Update README and documentation to reflect correct scopes required to use Experimenter. More documentation changes may follow in the future.


## Testing notes
This applies to the experimenter `/participants` route
1. Generate a single new account. In the resulting CSV file, the ID should contain only numbers, and be 10 digits long.
2. Generate multiple new accounts. In the resulting CSV file, all IDs should be numeric, and otherwise the format of the file should behave as normally.
3. Append an optional tag. The IDs should be of the form `1234567890-tagText`
4. Make sure that the newly created accounts are valid (can be used to log in)

If the new account cannot log in and be used on the actual site, wait 5 min and try again. We observed some sluggishness recently but the problem went away on its own.