### PR TITLE
Fix issue  with wrong permissions strings

### DIFF
--- a/app/controllers/project-settings.js
+++ b/app/controllers/project-settings.js
@@ -9,7 +9,7 @@ export default Ember.Controller.extend({
     collection: '',
 
     namespaceConfig: Ember.inject.service(),
-    namespace: Ember.computed.alias('namespaceConfig.namespace'),
+    namespaceId: Ember.computed.alias('namespaceConfig.namespace'),  // Namespace is apparently a reserved word.
 
     breadCrumb: 'Project configuration',
 
@@ -19,10 +19,10 @@ export default Ember.Controller.extend({
     availableCollections: ['accounts'],
 
     // Define the username format, eg Jam-authenticated users vs OSF provider
-    userPattern: Ember.computed('namespace', 'collection', function () {
+    userPattern: Ember.computed('namespaceId', 'collection', function () {
         const collection = this.get('collection');
         if (collection) {
-            return `jam-${this.get('namespace')}:accounts`;
+            return `jam-${this.get('namespaceId')}:accounts`;
         }
         return adminPattern;
     }),

--- a/app/templates/project-settings.hbs
+++ b/app/templates/project-settings.hbs
@@ -6,7 +6,7 @@
 <p>
     Add user to:
     <select onchange={{action (mut collection) value="target.value"}}>
-        <option value="" selected={{eq collection ''}}>Admin access for project: {{namespace}}</option>
+        <option value="" selected={{eq collection ''}}>Admin access for project: {{namespaceId}}</option>
         {{#each availableCollections as |name|}}
             <option value="{{name}}" selected={{eq collection name}}>Read access to collection: {{name}}</option>
         {{/each}}

--- a/app/utils/patterns.js
+++ b/app/utils/patterns.js
@@ -3,14 +3,13 @@
  */
 
 // Admin users are those authenticated via OSF
-// TODO: This wass a regex, now it's just a prefix
 const adminPattern = 'user-osf';
 
 /**
  * Create a regex object for matching users based on the specified external auth or Jam collection prefix.
  *
  * @param {String} prefix Eg 'user-osf'
- * @return {RegExp} A new regex object
+ * @return {RegExp} A new regex object that matches `prefix-abc`, `prefix.*`, or similar.
  */
 function makeUserPattern(prefix) {
     return new RegExp(`^${prefix}-(\\w\+|\\*)$`);


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-313

## Purpose
Fix an issue where the UI was always adding collection-level permissions for users in one specific namespace (experimenter), regardless of what namespace the user logged in under (eg ISP).

## Summary of changes
Apparently, `namespace` is (at least for controllers) a reserved word, and the global namespace property was overriding the value being set. Renamed the property.

## Testing notes
This bug previously slipped through because we were adding collection-level permissions on the `experimenter` JamDB namespace... a bucket of data that had the same name as the application (ember namespace).

Try giving a specific user collection-level permissions on another namespace (like ISP) instead, then see if that user is allowed to see the data involved. Discovered while testing ability of an ISP jam-auth user to access the new `/site-admin` page in ISP: https://github.com/CenterForOpenScience/isp/pull/107 .


[#LEI-313]