### PR TITLE
Show "in progress" UI during slow account batch creation

### DIFF
--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -170,7 +170,6 @@ export default Ember.Component.extend(Validations, {
             // as written, we don't retry to create those. If 3 of 100 requested items fail, we just create 97 items and call it a day.
             this.set('creating', true);
 
-
             // This step is very slow because each password has to be bcrypted- on the front end (jamdb implementation detail).
             //   Do that in a separate run loop so that UI status indicator can render while we wait; otherwise
             //   rerender blocks until after the server request has been sent.
@@ -195,9 +194,7 @@ export default Ember.Component.extend(Validations, {
                     })
                     .catch(() => this.get('toast').error('Could not create new accounts. Please try again later.'))
                     .finally(() => this.set('creating', false));
-
             });
-
         },
         addExtraField() {
             var next = this.get('nextExtra');

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -169,25 +169,35 @@ export default Ember.Component.extend(Validations, {
             // TODO: Use the server response errors field to identify any IDs that might already be in use:
             // as written, we don't retry to create those. If 3 of 100 requested items fail, we just create 97 items and call it a day.
             this.set('creating', true);
-            this._sendBulkRequest('account', accounts)
-                .then((res) => {
-                    if (res.length > 0) {
-                        // Store all the records that were successfully created,
-                        // adding them to all records from previous requests while on this page.
-                        // Eg, a combined CSV could be generated with 200 records.
-                        this.get('createdAccounts').push(...res);
-                        // This may sometimes be smaller than batchSize, in the rare event that a single record appears
-                        // in res.errors instead, eg because ID was already in use
-                        this.toast.info(`Successfully created ${res.length} accounts!`);
-                        this.send('downloadCSV');
-                    } else {
-                        // Likely, every ID in this request failed to create for some horrible reason (data.length=0
-                        // and errors.length=batchSize after filtering out spurious null entries)
-                        this.get('toast').error('Could not create new account(s). If this error persists, please contact support.');
-                    }
-                })
-                .catch(() => this.get('toast').error('Could not create new accounts. Please try again later.'))
-                .finally(() => this.set('creating', false));
+
+
+            // This step is very slow because each password has to be bcrypted- on the front end (jamdb implementation detail).
+            //   Do that in a separate run loop so that UI status indicator can render while we wait; otherwise
+            //   rerender blocks until after the server request has been sent.
+            this.rerender();
+            Ember.run.next(() => {
+                this._sendBulkRequest('account', accounts)
+                    .then((res) => {
+                        if (res.length > 0) {
+                            // Store all the records that were successfully created,
+                            // adding them to all records from previous requests while on this page.
+                            // Eg, a combined CSV could be generated with 200 records.
+                            this.get('createdAccounts').push(...res);
+                            // This may sometimes be smaller than batchSize, in the rare event that a single record appears
+                            // in res.errors instead, eg because ID was already in use
+                            this.toast.info(`Successfully created ${res.length} accounts!`);
+                            this.send('downloadCSV');
+                        } else {
+                            // Likely, every ID in this request failed to create for some horrible reason (data.length=0
+                            // and errors.length=batchSize after filtering out spurious null entries)
+                            this.get('toast').error('Could not create new account(s). If this error persists, please contact support.');
+                        }
+                    })
+                    .catch(() => this.get('toast').error('Could not create new accounts. Please try again later.'))
+                    .finally(() => this.set('creating', false));
+
+            });
+
         },
         addExtraField() {
             var next = this.get('nextExtra');

--- a/app/components/participant-creator/template.hbs
+++ b/app/components/participant-creator/template.hbs
@@ -1,7 +1,7 @@
 <div class="row participant-creator">
     <div class="{{if creating 'block-ui' 'block-ui-hidden'}}">
         <span class="block-ui-message">
-            Creating new records; please wait
+            Creating new records. This may take several minutes- please wait.
         </span>
     </div>
     <div class="col-md-6">


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-281

## Purpose
Batch creation of accounts is a slow process because of the need to bcrypt passwords on the front-end before submitting.

Previously, the component did not rerender with the "in progress" UI until the slow calculation was done... which made the page feel unresponsive for a long time.

This small change is intended to make the page show the waiting indicator sooner when relevant, and make the help text more relevant.

<img width="827" alt="screen shot 2016-12-06 at 11 43 56 am" src="https://cloud.githubusercontent.com/assets/2957073/20934482/4dcc46c0-bba9-11e6-8dee-506fb0b49638.png">


## Summary of changes
Move the serialization/ network request into a separate run loop so that loading indicator can be displayed and rerendered first.

## Testing notes
- There seems to be a bug in chrome (?) where the "save file" dialog box does not appear if you create several CSV files in a row. Refreshing the page/ loading in a new tab causes the page to work normally again. This is very annoying for QA; sorry.

- Create a batch of ~20 records; the save message should appear immediately, followed by a save-file dialog box about a minute later for `participants (x).csv`. (or the file should just save to the downloads folder for you, depending on browser settings)