### PR TITLE
[rfr] Fix tagged users so they can be given collection-level permissions

### DIFF
--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -69,7 +69,7 @@ export default Ember.Component.extend(Validations, {
     _generate(batchSize, tag) {
         var ret = [];
         for (let i = 0; i < batchSize; i++) {
-            ret.push(`${makeId(10)}${tag ? `-${tag}` : ''}`);
+            ret.push(`${makeId(10)}${tag ? `_${tag}` : ''}`);
         }
         return ret;
     },
@@ -140,7 +140,7 @@ export default Ember.Component.extend(Validations, {
 
     exampleId: Ember.computed('tag', function() {
         var tag = this.get('tag');
-        return `12345${tag ? `-${tag}` : ''}`;
+        return `12345${tag ? `_${tag}` : ''}`;
     }),
 
     actions: {

--- a/app/components/participant-creator/component.js
+++ b/app/components/participant-creator/component.js
@@ -69,7 +69,7 @@ export default Ember.Component.extend(Validations, {
     _generate(batchSize, tag) {
         var ret = [];
         for (let i = 0; i < batchSize; i++) {
-            ret.push(`${makeId(10)}${tag ? `_${tag}` : ''}`);
+            ret.push(`${makeId(10)}${tag ? `-${tag}` : ''}`);
         }
         return ret;
     },
@@ -140,7 +140,7 @@ export default Ember.Component.extend(Validations, {
 
     exampleId: Ember.computed('tag', function() {
         var tag = this.get('tag');
-        return `12345${tag ? `_${tag}` : ''}`;
+        return `12345${tag ? `-${tag}` : ''}`;
     }),
 
     actions: {

--- a/app/templates/experiments/info/results/all-loading.hbs
+++ b/app/templates/experiments/info/results/all-loading.hbs
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-xs-4 col-xs-offset-4">
-        <p>
+        <p class="text-center">
             Please wait. Our team of trained rescue cats is currently fetching your data.
         </p>
         <p class="text-center">

--- a/app/utils/patterns.js
+++ b/app/utils/patterns.js
@@ -12,7 +12,7 @@ const adminPattern = 'user-osf';
  * @return {RegExp} A new regex object that matches `prefix-abc`, `prefix.*`, or similar.
  */
 function makeUserPattern(prefix) {
-    return new RegExp(`^${prefix}-(\\w\+|\\*)$`);
+    return new RegExp(`^${prefix}-([\\d\\w\-]{3,64}|\\*)$`);
 }
 
 export {adminPattern, makeUserPattern};

--- a/tests/unit/utils/patterns-test.js
+++ b/tests/unit/utils/patterns-test.js
@@ -5,14 +5,17 @@ module('Unit | Utility | patterns');
 
 // Replace this with your real tests.
 test('Given prefix, returns a valid regex', function(assert) {
-    assert.expect(5);
+    assert.expect(7);
     let pattern = makeUserPattern('some-prefix');
 
     assert.ok(pattern.test('some-prefix-bob'),
         'Finds a specific suffix');
 
-    assert.ok(pattern.test('some-prefix-123_bob'),
-        'Finds a username with special characters');
+    assert.ok(pattern.test('some-prefix-123-bob'),
+        'Finds a username with hyphens');
+
+    assert.notOk(pattern.test('some-prefix-123-notallowed!'),
+        'Username characters must be alphanumeric, underscores, or hyphens');
 
     assert.ok(pattern.test('some-prefix-*'),
         'Finds a wildcard suffix');
@@ -23,4 +26,6 @@ test('Given prefix, returns a valid regex', function(assert) {
     assert.equal(pattern.exec('some-prefix-bob')[1], 'bob',
         'Username is captured');
 
+    assert.equal(pattern.exec('some-prefix-bob-123')[1], 'bob-123',
+        'Correctly extracts a username with hyphens');
 });

--- a/tests/unit/utils/patterns-test.js
+++ b/tests/unit/utils/patterns-test.js
@@ -5,13 +5,18 @@ module('Unit | Utility | patterns');
 
 // Replace this with your real tests.
 test('Given prefix, returns a valid regex', function(assert) {
-    assert.expect(4);
+    assert.expect(5);
     let pattern = makeUserPattern('some-prefix');
 
     assert.ok(pattern.test('some-prefix-bob'),
         'Finds a specific suffix');
+
+    assert.ok(pattern.test('some-prefix-123_bob'),
+        'Finds a username with special characters');
+
     assert.ok(pattern.test('some-prefix-*'),
         'Finds a wildcard suffix');
+
     assert.notOk(pattern.test('other-prefix-bob'),
         'Different prefixes do not match');
 


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-325

## Deployment notes
⚠️  Depends on the fix for https://github.com/CenterForOpenScience/jamdb/issues/11
(auto-deploys to staging but will need to be manually deployed to prod)

## Purpose
Although I can create a "tagged" username, I cannot give that person collection-level accounts permissions.

## Summary of changes
Update the regex for a valid username in the permissions selector, to be consistent with recent JamDB changes.

CenterForOpenScience/jamdb@815a522#diff-569da4ba3e8c7caea87c5d0e723268eeR14

## Testing notes

Generate a username on the participants page of experimenter, and add a tag:
`https://staging-experimenter.osf.io/participants`

Then try to add one of those user IDs to the permissions selector here:
`/settings?collection=accounts`

Previously it failed because hyphens are bad. Now, the username should be added to the list. There should be no errors on the JS console, and when you refresh the settings page the hyphenated username should still show up in the list.

Then visit the ISP `site-admin` page and confirm that the user who was given collection level permissions can see more than just their own record.

`/site-admin?siteId=test`

