### PR TITLE
Production site should build in production mode

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -31,19 +31,7 @@ module.exports = function (environment) {
         APP: {}
     };
 
-    if (environment === 'development') {
-        ENV.JAMDB = {
-            url: process.env.JAMDB_URL || 'http://localhost:1212',
-            namespace: process.env.JAMDB_NAMESPACE,
-            authorizer: 'osf-jwt'
-        };
-    } else if (environment === 'staging' || environment === 'production') {
-        ENV.JAMDB = {
-            url: process.env.JAMDB_URL,
-            namespace: process.env.JAMDB_NAMESPACE,
-            authorizer: 'osf-jwt'
-        };
-    } else if (environment === 'test') {
+    if (environment === 'test') {
         ENV.JAMDB = {
             url: '',
             namespace: 'test',
@@ -58,10 +46,13 @@ module.exports = function (environment) {
         ENV.APP.LOG_VIEW_LOOKUPS = false;
 
         ENV.APP.rootElement = '#ember-testing';
-    }
-
-    if (environment === 'production') {
-
+    } else {
+        // Get environment-specific settings from .env file
+        ENV.JAMDB = {
+            url: process.env.JAMDB_URL,
+            namespace: process.env.JAMDB_NAMESPACE,
+            authorizer: 'osf-jwt'
+        };
     }
 
     return ENV;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -75,8 +75,5 @@ module.exports = function(defaults) {
     // please specify an object with the list of modules as keys
     // along with the exports of each module as its value.
 
-    if (app.env === 'production') {
-        return require('broccoli-strip-debug')(app.toTree());
-    }
     return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-sass": "^0.7.0",
-    "broccoli-strip-debug": "^1.1.0",
     "ember-ajax": "^2.0.1",
     "ember-bootstrap": "^0.11.1",
     "ember-bootstrap-datetimepicker": "1.0.4",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-275

## Purpose
Make sure that production site builds in production mode

## Summary of changes
The only flags that `--environment` controls should be build related. (except where needed to disable behaviors for testing)

Otherwise all config should be sourced from the .env file

## Testing notes
We saw some odd regressions in Lookit when building as production. Generally manual re-QA the entire site and look for issues in the console/behaviors.

## Deployment notes
Will affect both staging and production sites. (prove out on staging first)

- Dockerfile changes
- No .env changes expected