### PR TITLE
Feature/require alpha in uids

### DIFF
--- a/app/workers/account-generator.js
+++ b/app/workers/account-generator.js
@@ -4,16 +4,17 @@
 importScripts('bcryptjs/dist/bcrypt.min.js');
 const bcrypt = dcodeIO.bcrypt;
 
-const bounds = new Set([
+const bounds = [
     [48, 57], // 0-9
     [65, 90], // A-Z
     [95, 95], // _
     [97, 122] // a-z
-]);
+];
 
 const possible = [];
 
-for (const bound of bounds) {
+for (let b = 0; b < bounds.length; b++) {
+    const bound = bounds[b];
     const upperBound = bound[1] + 1;
 
     for (let i = bound[0]; i < upperBound; i++) {
@@ -55,7 +56,7 @@ function makeId(len, enforceAlpha=true) {
 self.onmessage = event => {
     const {batchSize, studyId, extra, tag} = event.data;
     const records = [];
-    const idSet = new Set();
+    const idSet = [];
 
     for (let i = 0; i < batchSize; i++) {
         postMessage({
@@ -65,11 +66,11 @@ self.onmessage = event => {
         let id;
 
         // Check for duplicated IDs. Unlikely, but possible.
-        while (!id || idSet.has(id)) {
+        while (!id || ~idSet.indexOf(id)) {
             id = `${makeId(10, !tag)}${tag ? `-${tag}` : ''}`;
         }
 
-        idSet.add(id);
+        idSet.push(id);
 
         const salt = bcrypt.genSaltSync(12);
         const password = bcrypt.hashSync(studyId, salt).replace('$2a$', '$2b$');

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,10 +11,14 @@ module.exports = function(defaults) {
     const workerDestDir = '/assets/workers';
 
     const workers = transpiler(
-            new Funnel('app/workers', {
+        new Funnel('app/workers', {
             include: ['*.js'],
             destDir: workerDestDir
-        })
+        }),
+        {
+            comments: false,
+            compact: true
+        }
     );
 
     const workerDeps = new Funnel('bower_components', {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-347

## Purpose
JamDB requires part of the user ID to be a string, otherwise it treats it as an integer, which is causes issues.

## Summary of changes
* Updates to the web worker
* Update to the ember build to minify the output

## Testing notes
When no tag is present, the user IDs should be contain at least one alpha character or underscore (`A-Z`, `a-z`, or `_`). When a tag is present, the user IDs should be a 10-digit number followed by the dash and then the tag

