### PR TITLE
Add colors for active link and expand width to 100%

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -131,11 +131,17 @@ a.sub-navigation {
     color: white;
     text-decoration: none;
     padding: 12px;
+    width: 100%;
 }
 
 a.sub-navigation:visited {
     color: white;
     text-decoration: none;
+}
+
+a.sub-navigation.active {
+    color: $background-dark;
+    background-color: white;
 }
 
 a.sub-navigation:hover {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -97,8 +97,11 @@ body,
 }
 
 .main-navigation {
+    color: white;
+}
+
+.main-navigation.active {
     color: $background-dark;
-    background-color: #c0c0c0;
 }
 
 .selected > .fa {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-314

## Purpose
Active links didn't show as active

## Summary of changes
Updates the styling of active links in the subnav menu

### Before
![screen shot 2017-01-05 at 17 31 22](https://cloud.githubusercontent.com/assets/3374510/21700226/670b53ac-d36d-11e6-8779-15a3db1cf574.png)
![image](https://cloud.githubusercontent.com/assets/3374510/21700165/0220c8f0-d36d-11e6-8399-74ceb47fff70.png)

### After
![screen shot 2017-01-06 at 09 45 42](https://cloud.githubusercontent.com/assets/3374510/21721141/fc104ae8-d3f4-11e6-9150-8671f091b18c.png)
![screen shot 2017-01-06 at 09 45 52](https://cloud.githubusercontent.com/assets/3374510/21721144/ff0dcc84-d3f4-11e6-9287-a3cb6704d454.png)

## Testing notes
Click and hover on the links to ensure that they look like the photos above
