### PR TITLE
Add TOS link to footer of all pages

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -44,3 +44,13 @@
         {{outlet}}
     {{/if}}
 </div>
+
+<footer class="footer">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12 text-center">
+                <span class="text-center"><a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md" target="_blank" rel="nofollow noopener">Terms of Use</a></span>
+            </div>
+        </div>
+    </div>
+</footer>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">=6"
   },
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "bluebird": "^3.3.0",
     "broccoli-asset-rev": "^2.4.2",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-358

## Purpose
Add a footer link to the terms of service for all experimenter pages. You may have to scroll down slightly to see the link on the login page.

## Summary of changes
![screen shot 2017-01-25 at 12 57 32 pm](https://cloud.githubusercontent.com/assets/2957073/22303055/88ffc366-e2ff-11e6-990f-2b6ab0aeeceb.png)
![screen shot 2017-01-25 at 12 59 27 pm](https://cloud.githubusercontent.com/assets/2957073/22303060/8d9373fa-e2ff-11e6-9656-d0a6bf83e9f7.png)


## Testing notes
Go to the login page. Scroll down slightly and confirm that the TOS link is on the page.

Go the any page inside experimenter. Scroll to the bottom and confirm a TOS link is shown.

Confirm that the link opens in a new window when clicked and brings up the terms of service.
