### PR TITLE
Adding a cap on preview window.

### DIFF
--- a/app/components/export-tool/component.js
+++ b/app/components/export-tool/component.js
@@ -57,8 +57,15 @@ export default Ember.Component.extend({
      * @property {null|string} The processed data
      */
     processedData: Ember.computed('data', 'dataFormat', 'mappingFunction', function() {
-        let data = this.get('data') || [];
 
+        let data = this.get('data') || [];
+        var show = true;
+        var message = '';
+
+        if (data.length > 1000) {
+            show = false;
+            message = 'Dataset too large to preview. Please download to view.';
+        }
         if (data.toArray) {
             data = data.toArray();
         }
@@ -69,7 +76,11 @@ export default Ember.Component.extend({
 
         if (Ember.isPresent(dataArray)) {
             const mapped = mappingFunction ? dataArray.map(mappingFunction) : dataArray;
-            return this.convertToFormat(mapped, dataFormat);
+            return {
+                data: this.convertToFormat(mapped, dataFormat),
+                show: show,
+                message: message
+            };
         }
 
         return null;
@@ -172,7 +183,7 @@ export default Ember.Component.extend({
          * Creates a file for the user to download
          */
         downloadFile() {
-            const blob = new window.Blob([this.get('processedData')], {
+            const blob = new window.Blob([this.get('processedData.data')], {
                 type: 'text/plain;charset=utf-8'
             });
 

--- a/app/components/export-tool/template.hbs
+++ b/app/components/export-tool/template.hbs
@@ -8,8 +8,15 @@
             </select>
         </div>
     </div>
-    <div class="export-tool-textarea-container">
-        {{textarea value=processedData class="export-tool-textarea"}}
+    <div class="export-tool-textarea-container" open=>
+        
+        {{#if processedData.show}}
+            {{textarea value=processedData.data class="export-tool-textarea"}}
+        
+        {{else}}
+            {{textarea value=processedData.message class="export-tool-textarea"}}
+
+        {{/if}}
     </div>
     <div class="row text-center">
         <button class="btn btn-primary" {{action "downloadFile"}}>Download</button>


### PR DESCRIPTION
The json string would get so long that the preview window would crash the whole page.
Adding a cap on it fixes this.
It will only display a preview for datasets smaller than 1001 entries. Any larger than that and a message saying that the preview is unavailable is shown instead.

Refs: https://openscience.atlassian.net/browse/SVCS-434

## Purpose
ISP is having issues downloading large datasets in Chrome. This is caused by the preview window being passed too large of a json string to deal with. This fix causes the preview window to not show the data if it would be too large.


## Summary of changes
Changed the export_tool component.js file to include a show and message field. It evaluates on the length of all data. If the length is greater than 1000 (about the point where it gets a bit too slow), the preview is disabled and it shows a message in the preview window informing the user of this.  Change the template for the export-tool as well to match these changes.


## Testing notes
There are notes on the jira ticket for how to spoof large user amounts, if needed. 
 
This could have some impact on Lookit, and should be okayed on that front. 

Very large amounts of users( somewhere between 10,000 and 20,000+) start to hit the cap for the possible length of a string in javascript. At this point, things start to break (this will be handled on another ticket). So if you max out the data spoofing, then  things will start to break regardless. 
