### PR TITLE
Add link to Lookit docs

### DIFF
--- a/docs/source/experiments.md
+++ b/docs/source/experiments.md
@@ -125,7 +125,9 @@ This JSON document describes a fairly simple experiment. It has three basic part
             }
         }
     }
-}```
+}
+
+```
 
 
 ### A Lookit study schema

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 Welcome to Experimenter's documentation!
 ==========================================
 
-**If you are using Experimenter for Lookit studies, please see the updated `Lookit documentation <http://lookit.readthedocs.io/en/latest/>`_ instead.**
+**If you are using Experimenter for Lookit studies, please see the updated** `Lookit documentation <http://lookit.readthedocs.io/en/latest/>`_ instead.
 
 **NOTE: This documentation is a work in progress**
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,8 @@
 Welcome to Experimenter's documentation!
 ==========================================
 
+**If you are using Experimenter for Lookit studies, please see the updated `Lookit documentation <http://lookit.readthedocs.io/en/latest/>`_ instead.**
+
 **NOTE: This documentation is a work in progress**
 
 Experimenter is a platform for designing and administering experiments. It is built on top of `JamDB <https://github.com/CenterForOpenScience/jamdb/>`_ and `Ember.js <http://emberjs.com/>`_, and is developed by the `Center for Open Science <https://cos.io/>`_.


### PR DESCRIPTION
So that going forward researchers using Lookit can just refer to documentation maintained by Kim

