### PR TITLE
Up JamDB page size

### DIFF
--- a/app/routes/experiments/info/results/all.js
+++ b/app/routes/experiments/info/results/all.js
@@ -12,7 +12,7 @@ export default Ember.Route.extend({
     _fetchResults(collectionName, dest, page) {
         const options = {
             'filter[completed]': 1,
-            'page[size]': 100,
+            'page[size]': 500,
             page: page
         };
         return this.store.query(collectionName, options).then(res => {


### PR DESCRIPTION
Refs :https://openscience.atlassian.net/browse/SVCS-347

## Purpose
Up page size in request to JamDB

## Summary of changes
Upped max page size to 500.

## Testing notes

I verified that this was the correct place to up it by checking out the requests being sent in the chrome networks console.

